### PR TITLE
Fix task creation by wiring session into tRPC context

### DIFF
--- a/src/app/api/trpc/[trpc]/route.ts
+++ b/src/app/api/trpc/[trpc]/route.ts
@@ -1,4 +1,16 @@
 import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
+import { getServerSession } from 'next-auth';
 import { appRouter } from '@/server/api/root';
-const handler=(req:Request)=>fetchRequestHandler({endpoint:'/api/trpc',req,router:appRouter,createContext:()=>({})});
+import { authOptions } from '@/server/auth';
+
+const handler = (req: Request) =>
+  fetchRequestHandler({
+    endpoint: '/api/trpc',
+    req,
+    router: appRouter,
+    createContext: async () => ({
+      session: await getServerSession(authOptions),
+    }),
+  });
+
 export { handler as GET, handler as POST };

--- a/src/server/api/routers/task.ts
+++ b/src/server/api/routers/task.ts
@@ -1,10 +1,23 @@
 import { z } from 'zod';
-import { publicProcedure, router } from '../trpc';
+import { protectedProcedure, router } from '../trpc';
 import { db } from '@/server/db';
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/server/auth';
-export const taskRouter=router({
-  list: publicProcedure.query(async()=>{const session=await getServerSession(authOptions);const userId=(session?.user as any)?.id as string|undefined;if(!userId)return[];return db.task.findMany({where:{userId},orderBy:{createdAt:'desc'},select:{id:true,title:true,createdAt:true}});} ),
-  create: publicProcedure.input(z.object({title:z.string().min(1).max(200)})).mutation(async({input})=>{const session=await getServerSession(authOptions);const userId=(session?.user as any)?.id as string|undefined;if(!userId)throw new Error('Not authenticated');return db.task.create({data:{title:input.title,userId}});} ),
-  delete: publicProcedure.input(z.object({id:z.string().min(1)})).mutation(async({input})=>{const session=await getServerSession(authOptions);const userId=(session?.user as any)?.id as string|undefined;if(!userId)throw new Error('Not authenticated');return db.task.delete({where:{id:input.id}});} ),
+
+export const taskRouter = router({
+  list: protectedProcedure.query(async ({ ctx }) => {
+    const userId = (ctx.session.user as any).id as string;
+    return db.task.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+      select: { id: true, title: true, createdAt: true },
+    });
+  }),
+  create: protectedProcedure
+    .input(z.object({ title: z.string().min(1).max(200) }))
+    .mutation(async ({ input, ctx }) => {
+      const userId = (ctx.session.user as any).id as string;
+      return db.task.create({ data: { title: input.title, userId } });
+    }),
+  delete: protectedProcedure
+    .input(z.object({ id: z.string().min(1) }))
+    .mutation(async ({ input }) => db.task.delete({ where: { id: input.id } })),
 });

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -1,4 +1,20 @@
-import { initTRPC } from '@trpc/server';
+import { initTRPC, TRPCError } from '@trpc/server';
+import type { Session } from 'next-auth';
 import superjson from 'superjson';
-export const t=initTRPC.create({transformer:superjson});
-export const router=t.router;export const publicProcedure=t.procedure;
+
+type Context = {
+  session: Session | null;
+};
+
+export const t = initTRPC.context<Context>().create({
+  transformer: superjson,
+});
+
+export const router = t.router;
+export const publicProcedure = t.procedure;
+export const protectedProcedure = t.procedure.use(({ ctx, next }) => {
+  if (!ctx.session?.user?.id) {
+    throw new TRPCError({ code: 'UNAUTHORIZED' });
+  }
+  return next({ ctx: { session: ctx.session } });
+});


### PR DESCRIPTION
## Summary
- include session in tRPC context and add protectedProcedure
- require authentication for task list/create/delete

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm test` *(fails: no test files)*

------
https://chatgpt.com/codex/tasks/task_e_689927f6ca888320888f7332aac59122