### PR TITLE
feat: enable task title edits

### DIFF
--- a/src/components/task-list.tsx
+++ b/src/components/task-list.tsx
@@ -10,6 +10,10 @@ export function TaskList(){
     onSuccess: async () => utils.task.list.invalidate(),
     onError: (e) => alert(e.message || 'Failed to set due date')
   });
+  const rename = api.task.updateTitle.useMutation({
+    onSuccess: async () => utils.task.list.invalidate(),
+    onError: (e) => alert(e.message || 'Failed to update title')
+  });
 
   return (
     <div className="space-y-3">
@@ -31,7 +35,13 @@ export function TaskList(){
           return (
             <li key={t.id} className={`flex items-center justify-between rounded border px-3 py-2 ${overdue? 'border-red-500 bg-red-50 text-red-800 dark:bg-red-950 dark:text-red-200' : ''}`}>
               <div className="flex flex-col gap-1">
-                <span className="font-medium">{t.title}</span>
+                <input
+                  type="text"
+                  defaultValue={t.title}
+                  className="font-medium rounded border px-2 py-1"
+                  onBlur={(e)=>rename.mutate({ id: t.id, title: e.currentTarget.value })}
+                  onKeyDown={(e)=>{ if (e.key==='Enter') e.currentTarget.blur(); }}
+                />
                 <div className="flex items-center gap-2 text-xs opacity-80">
                   <label>Due:</label>
                   <input

--- a/src/server/api/routers/task.test.ts
+++ b/src/server/api/routers/task.test.ts
@@ -116,6 +116,21 @@ describe('taskRouter (no auth)', () => {
     expect(list2).toHaveLength(0);
   });
 
+  it('updates a task title', async () => {
+    const caller = taskRouter.createCaller({});
+    const created = await caller.create({ title: 'Old' });
+    const updated = await caller.updateTitle({ id: created.id, title: 'New Title' });
+    expect(updated.title).toBe('New Title');
+    const list = await caller.list();
+    expect(list[0]!.title).toBe('New Title');
+  });
+
+  it('rejects invalid titles on update', async () => {
+    const caller = taskRouter.createCaller({});
+    const created = await caller.create({ title: 'Valid' });
+    await expect(caller.updateTitle({ id: created.id, title: '' })).rejects.toThrow();
+  });
+
   it('sets a due date on an existing task', async () => {
     const caller = taskRouter.createCaller({});
     const created = await caller.create({ title: 'With due later' });

--- a/src/server/api/routers/task.ts
+++ b/src/server/api/routers/task.ts
@@ -55,6 +55,13 @@ export const taskRouter = router({
       }
       return db.task.update({ where: { id: input.id }, data: { dueAt: input.dueAt ?? null } });
     }),
+  updateTitle: publicProcedure
+    .input(
+      z.object({ id: z.string().min(1), title: z.string().min(1).max(200) })
+    )
+    .mutation(async ({ input }) => {
+      return db.task.update({ where: { id: input.id }, data: { title: input.title } });
+    }),
   delete: publicProcedure
     .input(z.object({ id: z.string().min(1) }))
     .mutation(async ({ input }) => {


### PR DESCRIPTION
## Summary
- allow updating task titles via new `updateTitle` mutation
- make task list titles editable and persist changes
- cover title updates with unit tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a8aa17514832089dedbf31aa69c70