### PR TITLE
feat: add local datetime utility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@trpc/server": "11.4.4",
         "bcryptjs": "^2.4.3",
         "clsx": "^2.1.1",
+        "date-fns": "^3.6.0",
         "lucide-react": "^0.440.0",
         "next": "14.2.5",
         "next-auth": "4.24.7",
@@ -2808,6 +2809,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@trpc/server": "11.4.4",
     "bcryptjs": "^2.4.3",
     "clsx": "^2.1.1",
+    "date-fns": "^3.6.0",
     "lucide-react": "^0.440.0",
     "next": "14.2.5",
     "next-auth": "4.24.7",

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React,{useMemo,useState} from 'react';
 import { api } from '@/server/api/react';
+import { formatLocalDateTime, parseLocalDateTime } from '@/lib/datetime';
 
 export default function TasksPage(){
   const [title,setTitle]=useState("");
@@ -40,7 +41,7 @@ export default function TasksPage(){
         onSubmit={(e)=>{
           e.preventDefault();
           if(!title.trim())return;
-          const dueAt = dueAtStr ? new Date(dueAtStr) : null;
+          const dueAt = dueAtStr ? parseLocalDateTime(dueAtStr) : null;
           create.mutate({title, dueAt});
         }}
       >
@@ -67,7 +68,7 @@ export default function TasksPage(){
             if(!dueAtStr){
               const d = new Date();
               d.setHours(23,59,0,0);
-              setDueAtStr(d.toISOString().slice(0,16));
+              setDueAtStr(formatLocalDateTime(d));
             }
             setShowDuePicker((v)=>!v);
           }}
@@ -101,10 +102,10 @@ export default function TasksPage(){
                   <input
                     type="datetime-local"
                     className="rounded border px-2 py-1"
-                    value={t.dueAt ? new Date(t.dueAt).toISOString().slice(0,16) : ''}
+                    value={t.dueAt ? formatLocalDateTime(new Date(t.dueAt)) : ''}
                     onChange={(e)=>{
                       const v = e.target.value;
-                      const date = v ? new Date(v) : null;
+                      const date = v ? parseLocalDateTime(v) : null;
                       setDue.mutate({ id: t.id, dueAt: date });
                     }}
                   />

--- a/src/components/new-task-form.tsx
+++ b/src/components/new-task-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useState } from 'react';
 import { api } from '@/server/api/react';
+import { formatLocalDateTime, parseLocalDateTime } from '@/lib/datetime';
 
 export function NewTaskForm(){
   const [title,setTitle]=useState("");
@@ -25,7 +26,7 @@ export function NewTaskForm(){
       onSubmit={(e)=>{
         e.preventDefault();
         if(!title.trim())return;
-        const dueAt = dueAtStr ? new Date(dueAtStr) : null;
+        const dueAt = dueAtStr ? parseLocalDateTime(dueAtStr) : null;
         create.mutate({title, dueAt});
       }}
     >
@@ -51,7 +52,7 @@ export function NewTaskForm(){
           if(!dueAtStr){
             const d = new Date();
             d.setHours(23,59,0,0);
-            setDueAtStr(d.toISOString().slice(0,16));
+            setDueAtStr(formatLocalDateTime(d));
           }
           setShowDuePicker(v=>!v);
         }}

--- a/src/components/task-list.tsx
+++ b/src/components/task-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useState } from 'react';
 import { api } from '@/server/api/react';
+import { formatLocalDateTime, parseLocalDateTime } from '@/lib/datetime';
 
 export function TaskList(){
   const [filter, setFilter] = useState<'all'|'overdue'|'today'>('all');
@@ -37,10 +38,10 @@ export function TaskList(){
                   <input
                     type="datetime-local"
                     className="rounded border px-2 py-1"
-                    value={t.dueAt ? new Date(t.dueAt).toISOString().slice(0,16) : ''}
+                    value={t.dueAt ? formatLocalDateTime(new Date(t.dueAt)) : ''}
                     onChange={(e)=>{
                       const v = e.target.value;
-                      const date = v ? new Date(v) : null;
+                      const date = v ? parseLocalDateTime(v) : null;
                       setDue.mutate({ id: t.id, dueAt: date });
                     }}
                   />

--- a/src/lib/datetime.test.ts
+++ b/src/lib/datetime.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { formatLocalDateTime, parseLocalDateTime } from './datetime';
+
+describe('datetime utility', () => {
+  it('round trips preserving local timezone', () => {
+    const originalTZ = process.env.TZ;
+    process.env.TZ = 'America/New_York';
+
+    const date = new Date(2024, 0, 1, 12, 30);
+    const formatted = formatLocalDateTime(date);
+    expect(formatted).toBe('2024-01-01T12:30');
+    expect(formatted).not.toBe(date.toISOString().slice(0, 16));
+
+    const parsed = parseLocalDateTime(formatted);
+    expect(parsed.getTime()).toBe(date.getTime());
+
+    process.env.TZ = originalTZ;
+  });
+});

--- a/src/lib/datetime.ts
+++ b/src/lib/datetime.ts
@@ -1,0 +1,11 @@
+import { format, parse } from 'date-fns';
+
+const DATETIME_LOCAL_FORMAT = "yyyy-MM-dd'T'HH:mm";
+
+export function formatLocalDateTime(date: Date): string {
+  return format(date, DATETIME_LOCAL_FORMAT);
+}
+
+export function parseLocalDateTime(value: string): Date {
+  return parse(value, DATETIME_LOCAL_FORMAT, new Date(0));
+}


### PR DESCRIPTION
## Summary
- add date-fns-based helpers to format/parse local datetime strings
- use datetime helpers in task creation and editing components
- test round-trip conversion respects local timezone

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689a8aad26ec8320a9e9d7b8e24c311c