### PR TITLE
feat: add default end-of-today helper

### DIFF
--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React,{useMemo,useState} from 'react';
 import { api } from '@/server/api/react';
+import { defaultEndOfToday } from '@/lib/datetime';
 
 export default function TasksPage(){
   const [title,setTitle]=useState("");
@@ -63,11 +64,8 @@ export default function TasksPage(){
           type="button"
           className="rounded border px-4 py-2 shrink-0 bg-gray-100 text-gray-900 border-gray-300 dark:bg-gray-800 dark:text-gray-100 dark:border-gray-700"
           onClick={()=>{
-            // Default to end of today if empty
             if(!dueAtStr){
-              const d = new Date();
-              d.setHours(23,59,0,0);
-              setDueAtStr(d.toISOString().slice(0,16));
+              setDueAtStr(defaultEndOfToday());
             }
             setShowDuePicker((v)=>!v);
           }}

--- a/src/components/new-task-form.tsx
+++ b/src/components/new-task-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useState } from 'react';
 import { api } from '@/server/api/react';
+import { defaultEndOfToday } from '@/lib/datetime';
 
 export function NewTaskForm(){
   const [title,setTitle]=useState("");
@@ -49,9 +50,7 @@ export function NewTaskForm(){
         className="rounded border px-4 py-2 shrink-0 bg-gray-100 text-gray-900 border-gray-300 dark:bg-gray-800 dark:text-gray-100 dark:border-gray-700"
         onClick={()=>{
           if(!dueAtStr){
-            const d = new Date();
-            d.setHours(23,59,0,0);
-            setDueAtStr(d.toISOString().slice(0,16));
+            setDueAtStr(defaultEndOfToday());
           }
           setShowDuePicker(v=>!v);
         }}

--- a/src/lib/datetime.ts
+++ b/src/lib/datetime.ts
@@ -1,0 +1,5 @@
+export function defaultEndOfToday(): string {
+  const d = new Date();
+  d.setHours(23, 59, 0, 0);
+  return d.toISOString().slice(0, 16);
+}


### PR DESCRIPTION
## Summary
- add `defaultEndOfToday` helper to centralize due date default
- use helper in NewTaskForm and TasksPage instead of inline code

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689a8aaa556c83208984b297aad3f0ce