### PR TITLE
feat: add reusable button component

### DIFF
--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -1,5 +1,6 @@
 "use client";
-import React,{useMemo,useState} from 'react';
+import React,{useState} from 'react';
+import { Button } from '@/components/ui/button';
 import { api } from '@/server/api/react';
 import { formatLocalDateTime, parseLocalDateTime } from '@/lib/datetime';
 
@@ -60,9 +61,10 @@ export default function TasksPage(){
             aria-label="Due date"
           />
         )}
-        <button
+        <Button
           type="button"
-          className="rounded border px-4 py-2 shrink-0 bg-gray-100 text-gray-900 border-gray-300 dark:bg-gray-800 dark:text-gray-100 dark:border-gray-700"
+          variant="secondary"
+          className="shrink-0"
           onClick={()=>{
             if(!dueAtStr){
               const d = new Date();
@@ -74,8 +76,8 @@ export default function TasksPage(){
           aria-label="Toggle due date picker"
         >
           Set Due Date
-        </button>
-        <button className="rounded bg-black px-4 py-2 text-white dark:bg-white dark:text-black shrink-0" disabled={create.isPending}>Add</button>
+        </Button>
+        <Button type="submit" className="shrink-0" disabled={create.isPending}>Add</Button>
       </form>
       <div className="flex items-center gap-2">
         <label className="text-sm opacity-80">Filter:</label>
@@ -109,14 +111,26 @@ export default function TasksPage(){
                     }}
                   />
                   {t.dueAt && (
-                    <button className="underline" onClick={()=>setDue.mutate({ id: t.id, dueAt: null })}>Clear</button>
+                    <Button
+                      variant="secondary"
+                      className="underline bg-transparent border-0 px-0 py-0"
+                      onClick={()=>setDue.mutate({ id: t.id, dueAt: null })}
+                    >
+                      Clear
+                    </Button>
                   )}
                   {t.dueAt && (
                     <span className="ml-2">{overdue ? 'Overdue' : `Due ${new Date(t.dueAt).toLocaleString()}`}</span>
                   )}
                 </div>
               </div>
-              <button className="text-sm underline" onClick={()=>del.mutate({id:t.id})}>Delete</button>
+              <Button
+                variant="danger"
+                className="text-sm underline bg-transparent px-0 py-0 text-red-600"
+                onClick={()=>del.mutate({id:t.id})}
+              >
+                Delete
+              </Button>
             </li>
           );
         })}

--- a/src/components/new-task-form.tsx
+++ b/src/components/new-task-form.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { useState } from 'react';
+import { Button } from '@/components/ui/button';
 import { api } from '@/server/api/react';
 import { formatLocalDateTime, parseLocalDateTime } from '@/lib/datetime';
 
@@ -42,9 +43,10 @@ export function NewTaskForm(){
           aria-label="Due date"
         />)
       }
-      <button
+      <Button
         type="button"
-        className="rounded border px-4 py-2 shrink-0 bg-gray-100 text-gray-900 border-gray-300 dark:bg-gray-800 dark:text-gray-100 dark:border-gray-700"
+        variant="secondary"
+        className="shrink-0"
         onClick={()=>{
           if(!dueAtStr){
             const d = new Date();
@@ -56,8 +58,8 @@ export function NewTaskForm(){
         aria-label="Toggle due date picker"
       >
         Set Due Date
-      </button>
-      <button className="rounded bg-black px-4 py-2 text-white disabled:opacity-60 dark:bg-white dark:text-black shrink-0" disabled={create.isPending}>Add</button>
+      </Button>
+      <Button type="submit" className="shrink-0" disabled={create.isPending}>Add</Button>
       {create.error && (
         <p role="alert" className="w-full text-red-500">
           {create.error.message}

--- a/src/components/task-list.test.tsx
+++ b/src/components/task-list.test.tsx
@@ -24,6 +24,15 @@ vi.mock('@/server/api/react', () => ({
           error: { message: 'Failed to set due date' },
         }),
       },
+      updateTitle: {
+        useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+      },
+      delete: {
+        useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+      },
+      setStatus: {
+        useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+      },
     },
   },
 }));

--- a/src/components/task-list.tsx
+++ b/src/components/task-list.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { useState } from 'react';
+import { Button } from '@/components/ui/button';
 import { api } from '@/server/api/react';
 import { formatLocalDateTime, parseLocalDateTime } from '@/lib/datetime';
 
@@ -71,7 +72,13 @@ export function TaskList(){
                     }}
                   />
                   {t.dueAt && (
-                    <button className="underline" onClick={()=>setDue.mutate({ id: t.id, dueAt: null })}>Clear</button>
+                    <Button
+                      variant="secondary"
+                      className="underline bg-transparent border-0 px-0 py-0"
+                      onClick={()=>setDue.mutate({ id: t.id, dueAt: null })}
+                    >
+                      Clear
+                    </Button>
                   )}
                   {t.dueAt && (
                     <span className="ml-2">{overdue ? 'Overdue' : `Due ${new Date(t.dueAt).toLocaleString()}`}</span>
@@ -79,7 +86,13 @@ export function TaskList(){
                 </div>
               </div>
               </div>
-              <button className="text-sm underline" onClick={()=>del.mutate({ id: t.id })}>Delete</button>
+              <Button
+                variant="danger"
+                className="text-sm underline bg-transparent px-0 py-0 text-red-600"
+                onClick={()=>del.mutate({ id: t.id })}
+              >
+                Delete
+              </Button>
             </li>
           );
         })}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { clsx } from 'clsx';
+
+export type ButtonVariant = 'primary' | 'secondary' | 'danger';
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+}
+
+export function Button({
+  variant = 'primary',
+  className,
+  ...props
+}: ButtonProps) {
+  const base =
+    'inline-flex items-center justify-center rounded px-4 py-2 text-sm font-medium focus:outline-none disabled:opacity-60';
+  const variants: Record<ButtonVariant, string> = {
+    primary: 'bg-black text-white dark:bg-white dark:text-black',
+    secondary:
+      'bg-gray-100 text-gray-900 border border-gray-300 dark:bg-gray-800 dark:text-gray-100 dark:border-gray-700',
+    danger: 'bg-red-600 text-white hover:bg-red-700 dark:bg-red-700',
+  };
+
+  return (
+    <button className={clsx(base, variants[variant], className)} {...props} />
+  );
+}
+
+export default Button;


### PR DESCRIPTION
## Summary
- add typed Button component with primary, secondary, and danger variants
- swap inline buttons in task form and list for new Button component
- extend task list test mocks for additional API calls

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689b77414aec832084ca6695dcb49cc0