### PR TITLE
feat: add theme toggle for light and dark modes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "lucide-react": "^0.440.0",
         "next": "14.2.5",
         "next-auth": "4.24.7",
+        "next-themes": "^0.4.6",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "superjson": "^2.2.1",
@@ -5722,6 +5723,16 @@
         "nodemailer": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lucide-react": "^0.440.0",
     "next": "14.2.5",
     "next-auth": "4.24.7",
+    "next-themes": "^0.4.6",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "superjson": "^2.2.1",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,24 @@
 import "./../styles/globals.css";
 import React from "react";
 import Providers from "./providers";
-export const metadata = { title: "Student Task Scheduler", description: "Plan, prioritize, and finish tasks." };
+import ThemeToggle from "@/components/theme-toggle";
+
+export const metadata = {
+  title: "Student Task Scheduler",
+  description: "Plan, prioritize, and finish tasks.",
+};
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
-  return (<html lang="en"><body className="min-h-screen bg-white text-slate-900 antialiased dark:bg-slate-950 dark:text-slate-100"><div className="mx-auto max-w-5xl p-6"><Providers>{children}</Providers></div></body></html>);
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body className="min-h-screen bg-white text-slate-900 antialiased dark:bg-slate-950 dark:text-slate-100">
+        <div className="mx-auto max-w-5xl p-6">
+          <Providers>
+            <ThemeToggle />
+            {children}
+          </Providers>
+        </div>
+      </body>
+    </html>
+  );
 }

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
 import { httpBatchLink } from "@trpc/client";
 import superjson from "superjson";
+import { ThemeProvider } from "next-themes";
 import { api } from "@/server/api/react";
 export default function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = React.useState(() => new QueryClient());
@@ -19,10 +20,10 @@ export default function Providers({ children }: { children: React.ReactNode }) {
     })
   );
   return (
-    <api.Provider client={trpcClient} queryClient={queryClient}>
-      <QueryClientProvider client={queryClient}>
-        {children}
-      </QueryClientProvider>
-    </api.Provider>
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      <api.Provider client={trpcClient} queryClient={queryClient}>
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      </api.Provider>
+    </ThemeProvider>
   );
 }

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,24 @@
+"use client";
+import React from "react";
+import { useTheme } from "next-themes";
+import { Moon, Sun } from "lucide-react";
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => setMounted(true), []);
+  if (!mounted) {
+    return null;
+  }
+  const toggle = () => setTheme(theme === "dark" ? "light" : "dark");
+  return (
+    <button
+      aria-label="Toggle theme"
+      className="rounded border px-3 py-2"
+      onClick={toggle}
+      type="button"
+    >
+      {theme === "dark" ? <Sun size={16} /> : <Moon size={16} />}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add next-themes dependency and ThemeToggle component
- wrap app with ThemeProvider and render theme toggle in layout

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot read properties of undefined (reading 'useMutation'))*

------
https://chatgpt.com/codex/tasks/task_e_689b776015088320836f49d8a2dcb458