### PR TITLE
feat: animate task list items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "bcryptjs": "^2.4.3",
         "clsx": "^2.1.1",
         "date-fns": "^3.6.0",
+        "framer-motion": "^11.18.2",
         "lucide-react": "^0.440.0",
         "next": "14.2.5",
         "next-auth": "4.24.7",
@@ -4191,6 +4192,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5585,6 +5613,21 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "bcryptjs": "^2.4.3",
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",
+    "framer-motion": "^11.18.2",
     "lucide-react": "^0.440.0",
     "next": "14.2.5",
     "next-auth": "4.24.7",

--- a/src/components/task-list.test.tsx
+++ b/src/components/task-list.test.tsx
@@ -24,6 +24,15 @@ vi.mock('@/server/api/react', () => ({
           error: { message: 'Failed to set due date' },
         }),
       },
+      updateTitle: {
+        useMutation: () => ({ mutate: vi.fn(), error: undefined }),
+      },
+      delete: {
+        useMutation: () => ({ mutate: vi.fn(), error: undefined }),
+      },
+      setStatus: {
+        useMutation: () => ({ mutate: vi.fn(), error: undefined }),
+      },
     },
   },
 }));

--- a/src/components/task-list.tsx
+++ b/src/components/task-list.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
 import { api } from '@/server/api/react';
 import { formatLocalDateTime, parseLocalDateTime } from '@/lib/datetime';
 
@@ -37,11 +38,19 @@ export function TaskList(){
         </select>
       </div>
       <ul className="space-y-2">
+        <AnimatePresence>
         {tasks.data?.map((t)=>{
           const overdue = t.dueAt ? new Date(t.dueAt) < new Date() : false;
           const done = t.status === 'DONE';
           return (
-            <li key={t.id} className={`flex items-center justify-between rounded border px-3 py-2 ${overdue? 'border-red-500 bg-red-50 text-red-800 dark:bg-red-950 dark:text-red-200' : ''}`}>
+            <motion.li
+              key={t.id}
+              initial={{ opacity: 0, y: -8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 8 }}
+              layout
+              className={`flex items-center justify-between rounded border px-3 py-2 ${overdue? 'border-red-500 bg-red-50 text-red-800 dark:bg-red-950 dark:text-red-200' : ''}`}
+            >
               <div className="flex items-start gap-2 flex-1">
                 <input
                   type="checkbox"
@@ -80,9 +89,10 @@ export function TaskList(){
               </div>
               </div>
               <button className="text-sm underline" onClick={()=>del.mutate({ id: t.id })}>Delete</button>
-            </li>
+            </motion.li>
           );
         })}
+        </AnimatePresence>
         {tasks.isLoading && <li>Loading…</li>}
         {!tasks.isLoading && (tasks.data?.length ?? 0) === 0 && <li className="opacity-60">No tasks.</li>}
       </ul>


### PR DESCRIPTION
## Summary
- add framer-motion for UI animations
- animate task list items with fade/slide transitions
- mock missing task mutations in tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b7747a11c8320a523bd263ff1ed24