### PR TITLE
fix: add accessibility labels to new task form inputs

### DIFF
--- a/src/components/new-task-form.tsx
+++ b/src/components/new-task-form.tsx
@@ -32,6 +32,7 @@ export function NewTaskForm(){
         placeholder="Add a task…"
         value={title}
         onChange={(e)=>setTitle(e.target.value)}
+        aria-label="Task title"
       />
       {showDuePicker && (
         <input
@@ -39,7 +40,7 @@ export function NewTaskForm(){
           className="rounded border px-3 py-2 shrink-0"
           value={dueAtStr}
           onChange={(e)=>setDueAtStr(e.target.value)}
-          aria-label="Due date"
+          aria-label="Task due date"
         />)
       }
       <button


### PR DESCRIPTION
## Summary
- add aria-label to task title input in new task form
- label due date picker with aria-label

## Testing
- `npm run lint`
- `npm test` *(fails: TypeError: Cannot read properties of undefined (reading 'useMutation'))*

------
https://chatgpt.com/codex/tasks/task_e_689b775dde708320b5c43dfeed180849