### PR TITLE
feat: add task list loading skeleton

### DIFF
--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -2,6 +2,7 @@
 import React,{useMemo,useState} from 'react';
 import { api } from '@/server/api/react';
 import { formatLocalDateTime, parseLocalDateTime } from '@/lib/datetime';
+import { TaskListSkeleton } from '@/components/task-list-skeleton';
 
 export default function TasksPage(){
   const [title,setTitle]=useState("");
@@ -120,7 +121,7 @@ export default function TasksPage(){
             </li>
           );
         })}
-        {list.isLoading&&<li>Loading…</li>}
+        {list.isLoading && <TaskListSkeleton />}
         {!list.isLoading&&(list.data?.length??0)===0&&<li className="opacity-60">No tasks yet.</li>}
       </ul>
     </main>

--- a/src/components/task-list-skeleton.tsx
+++ b/src/components/task-list-skeleton.tsx
@@ -1,0 +1,31 @@
+'use client';
+import React from 'react';
+
+export function TaskListSkeleton(){
+  return (
+    <li className="flex justify-center p-2" aria-label="Loading tasks">
+      <svg
+        className="h-5 w-5 animate-spin text-gray-500"
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        role="status"
+        aria-label="Loading"
+      >
+        <circle
+          className="opacity-25"
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="currentColor"
+          strokeWidth="4"
+        />
+        <path
+          className="opacity-75"
+          fill="currentColor"
+          d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+        />
+      </svg>
+    </li>
+  );
+}

--- a/src/components/task-list.test.tsx
+++ b/src/components/task-list.test.tsx
@@ -1,21 +1,24 @@
 // @vitest-environment jsdom
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import * as matchers from '@testing-library/jest-dom/matchers';
 expect.extend(matchers);
 import { TaskList } from './task-list';
+
+const defaultQuery = {
+  data: [{ id: '1', title: 'Test', dueAt: null }],
+  isLoading: false,
+  error: undefined,
+};
+const useQueryMock = vi.fn().mockReturnValue(defaultQuery);
 
 vi.mock('@/server/api/react', () => ({
   api: {
     useUtils: () => ({ task: { list: { invalidate: vi.fn() } } }),
     task: {
       list: {
-        useQuery: () => ({
-          data: [{ id: '1', title: 'Test', dueAt: null }],
-          isLoading: false,
-          error: undefined,
-        }),
+        useQuery: (...args: unknown[]) => useQueryMock(...args),
       },
       setDueDate: {
         useMutation: () => ({
@@ -24,11 +27,35 @@ vi.mock('@/server/api/react', () => ({
           error: { message: 'Failed to set due date' },
         }),
       },
+      updateTitle: {
+        useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }),
+      },
+      delete: {
+        useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }),
+      },
+      setStatus: {
+        useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }),
+      },
     },
   },
 }));
 
+afterEach(() => {
+  cleanup();
+  useQueryMock.mockReturnValue(defaultQuery);
+});
+
 describe('TaskList', () => {
+  it('shows loading skeleton when tasks are loading', () => {
+    useQueryMock.mockReturnValueOnce({
+      data: [],
+      isLoading: true,
+      error: undefined,
+    });
+    render(<TaskList />);
+    expect(screen.getByLabelText('Loading tasks')).toBeInTheDocument();
+  });
+
   it('shows error message when setting due date fails', () => {
     render(<TaskList />);
     expect(screen.getByText('Failed to set due date')).toBeInTheDocument();

--- a/src/components/task-list.tsx
+++ b/src/components/task-list.tsx
@@ -2,6 +2,7 @@
 import React, { useState } from 'react';
 import { api } from '@/server/api/react';
 import { formatLocalDateTime, parseLocalDateTime } from '@/lib/datetime';
+import { TaskListSkeleton } from './task-list-skeleton';
 
 export function TaskList(){
   const [filter, setFilter] = useState<'all'|'overdue'|'today'>('all');
@@ -83,7 +84,7 @@ export function TaskList(){
             </li>
           );
         })}
-        {tasks.isLoading && <li>Loading…</li>}
+        {tasks.isLoading && <TaskListSkeleton />}
         {!tasks.isLoading && (tasks.data?.length ?? 0) === 0 && <li className="opacity-60">No tasks.</li>}
       </ul>
       {tasks.error && (


### PR DESCRIPTION
## Summary
- add TaskListSkeleton component with animated spinner
- use skeleton in TaskList and tasks page
- test loading skeleton behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b776180708320a2733c71e6ea0380