### PR TITLE
feat: move theme toggle to header

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import "./../styles/globals.css";
 import React from "react";
 import Providers from "./providers";
-import ThemeToggle from "@/components/theme-toggle";
 
 export const metadata = {
   title: "Student Task Scheduler",
@@ -13,7 +12,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" suppressHydrationWarning>
       <body className="min-h-screen bg-white text-slate-900 antialiased dark:bg-slate-950 dark:text-slate-100">
         <Providers>
-          <ThemeToggle />
           <div className="mx-auto max-w-5xl p-6">
             {children}
           </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { TaskList } from "@/components/task-list";
 import { NewTaskForm } from "@/components/new-task-form";
+import ThemeToggle from "@/components/theme-toggle";
 export default function HomePage() {
   return (
     <main className="space-y-8">
@@ -10,6 +11,7 @@ export default function HomePage() {
           <h1 className="text-3xl font-bold">Your Tasks</h1>
           <p className="text-sm text-slate-600 dark:text-slate-300">No sign in required.</p>
         </div>
+        <ThemeToggle />
       </header>
       <NewTaskForm />
       <TaskList />

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { NewTaskForm } from "@/components/new-task-form";
 import { TaskList } from "@/components/task-list";
+import ThemeToggle from "@/components/theme-toggle";
 
 export default function TasksPage() {
   return (
@@ -14,6 +15,7 @@ export default function TasksPage() {
             Create and manage your tasks — no sign in required.
           </p>
         </div>
+        <ThemeToggle />
       </header>
       <NewTaskForm />
       <TaskList />

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -10,11 +10,17 @@ export default function ThemeToggle() {
   if (!mounted) {
     return null;
   }
-  const toggle = () => setTheme(theme === "dark" ? "light" : "dark");
+  const toggle = () => {
+    const nextTheme = theme === "dark" ? "light" : "dark";
+    setTheme(nextTheme);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem("theme", nextTheme);
+    }
+  };
   return (
     <button
       aria-label="Toggle theme"
-      className="fixed bottom-4 left-4 z-50 rounded-md border px-3 py-2 bg-white/80 dark:bg-slate-900/80 backdrop-blur shadow hover:bg-white dark:hover:bg-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+      className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-transparent bg-transparent hover:bg-slate-100 dark:hover:bg-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
       onClick={toggle}
       type="button"
     >


### PR DESCRIPTION
## Summary
- persist theme choice in localStorage using next-themes
- restyle theme toggle as icon-only button
- move theme toggle into page headers and align right

## Testing
- `npm run lint`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cdaf49de483208a9dcd69c62cae49