### PR TITLE
feat: use calendar icon for due date toggle

### DIFF
--- a/src/components/new-task-form.test.tsx
+++ b/src/components/new-task-form.test.tsx
@@ -50,4 +50,12 @@ describe('NewTaskForm', () => {
     expect(screen.queryByText('Title is required')).not.toBeInTheDocument();
     expect(input).not.toHaveAttribute('aria-invalid');
   });
+
+  it('toggles due date picker with calendar icon', () => {
+    render(<NewTaskForm />);
+    const toggle = screen.getByLabelText('Toggle due date picker');
+    expect(screen.queryByLabelText('Task due date')).not.toBeInTheDocument();
+    fireEvent.click(toggle);
+    expect(screen.getByLabelText('Task due date')).toBeInTheDocument();
+  });
 });

--- a/src/components/new-task-form.tsx
+++ b/src/components/new-task-form.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { api } from '@/server/api/react';
 import { formatLocalDateTime, parseLocalDateTime } from '@/lib/datetime';
 import { toast } from 'react-hot-toast';
+import { Calendar } from 'lucide-react';
 
 export function NewTaskForm(){
   const [title, setTitle] = useState("");
@@ -39,17 +40,34 @@ export function NewTaskForm(){
         create.mutate({title, dueAt});
       }}
     >
-      <input
-        className={`flex-1 rounded border px-3 py-2 ${titleError ? 'border-red-500' : ''}`}
-        placeholder="Add a task…"
-        value={title}
-        aria-label="Task title"
-        aria-invalid={titleError ? 'true' : undefined}
-        onChange={(e)=>{
-          setTitle(e.target.value);
-          if (titleError && e.target.value.trim()) setTitleError("");
-        }}
-      />
+      <div className="relative flex-1">
+        <input
+          className={`w-full rounded border pl-3 pr-8 py-2 ${titleError ? 'border-red-500' : ''}`}
+          placeholder="Add a task…"
+          value={title}
+          aria-label="Task title"
+          aria-invalid={titleError ? 'true' : undefined}
+          onChange={(e)=>{
+            setTitle(e.target.value);
+            if (titleError && e.target.value.trim()) setTitleError("");
+          }}
+        />
+        <button
+          type="button"
+          aria-label="Toggle due date picker"
+          className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
+          onClick={()=>{
+            if(!dueAtStr){
+              const d = new Date();
+              d.setHours(23,59,0,0);
+              setDueAtStr(formatLocalDateTime(d));
+            }
+            setShowDuePicker(v=>!v);
+          }}
+        >
+          <Calendar className="h-4 w-4" />
+        </button>
+      </div>
       {showDuePicker && (
         <input
           type="datetime-local"
@@ -59,22 +77,7 @@ export function NewTaskForm(){
           aria-label="Task due date"
         />)
       }
-      <Button
-        type="button"
-        variant="secondary"
-        className="shrink-0"
-        onClick={()=>{
-          if(!dueAtStr){
-            const d = new Date();
-            d.setHours(23,59,0,0);
-            setDueAtStr(formatLocalDateTime(d));
-          }
-          setShowDuePicker(v=>!v);
-        }}
-        aria-label="Toggle due date picker"
-      >
-        Set Due Date
-      </Button>
+      
       <Button type="submit" className="shrink-0" disabled={create.isPending}>Add</Button>
       {titleError && (
         <p role="alert" className="w-full text-red-500">


### PR DESCRIPTION
## Summary
- replace "Set Due Date" button with calendar icon inside task field
- verify calendar icon toggles due date picker

## Testing
- `npm run lint`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cdafbe2d08320b7c1084e3fa8c1a4