### PR TITLE
feat: add task search filtering

### DIFF
--- a/src/components/task-list.test.tsx
+++ b/src/components/task-list.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import React from 'react';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import * as matchers from '@testing-library/jest-dom/matchers';
 expect.extend(matchers);
@@ -60,5 +60,13 @@ describe('TaskList', () => {
   it('shows error message when setting due date fails', () => {
     render(<TaskList />);
     expect(screen.getByText('Failed to set due date')).toBeInTheDocument();
+  });
+
+  it('filters tasks based on search query', () => {
+    render(<TaskList />);
+    const input = screen.getByPlaceholderText('Search tasks...');
+    fireEvent.change(input, { target: { value: 'Nope' } });
+    expect(screen.queryByText('Test')).not.toBeInTheDocument();
+    expect(screen.getByText('No tasks.')).toBeInTheDocument();
   });
 });

--- a/src/components/task-list.tsx
+++ b/src/components/task-list.tsx
@@ -11,6 +11,7 @@ import { TaskFilterTabs } from "./task-filter-tabs";
 
 export function TaskList() {
   const [filter, setFilter] = useState<"all" | "overdue" | "today">("all");
+  const [query, setQuery] = useState("");
   const utils = api.useUtils();
 
   const queryInput = React.useMemo(() => {
@@ -30,6 +31,14 @@ export function TaskList() {
   }, [filter]);
 
   const tasks = api.task.list.useQuery(queryInput);
+
+  const filteredTasks = React.useMemo(
+    () =>
+      tasks.data?.filter((t) =>
+        t.title.toLowerCase().includes(query.toLowerCase())
+      ) ?? [],
+    [tasks.data, query]
+  );
 
   const setDue = api.task.setDueDate.useMutation({
     onSuccess: async () => utils.task.list.invalidate(),
@@ -53,10 +62,17 @@ export function TaskList() {
 
   return (
     <div className="space-y-3">
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.currentTarget.value)}
+        placeholder="Search tasks..."
+        className="w-full bg-transparent border-0 px-0 py-1 outline-none placeholder:text-muted-foreground"
+      />
       <TaskFilterTabs value={filter} onChange={setFilter} />
       <ul className="space-y-2">
         <AnimatePresence>
-          {tasks.data?.map((t) => {
+          {filteredTasks.map((t) => {
             const overdue = t.dueAt ? new Date(t.dueAt) < new Date() : false;
             const done = t.status === "DONE";
             return (
@@ -141,7 +157,7 @@ export function TaskList() {
         </AnimatePresence>
 
         {tasks.isLoading && <TaskListSkeleton />}
-        {!tasks.isLoading && (tasks.data?.length ?? 0) === 0 && (
+        {!tasks.isLoading && filteredTasks.length === 0 && (
           <li className="opacity-60">No tasks.</li>
         )}
       </ul>


### PR DESCRIPTION
## Summary
- add search box to task list
- filter tasks client-side by search query
- test task list filtering

## Testing
- `npm run lint`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cdb09207883209ba4fa91558c604a