### PR TITLE
feat: show task completion ratio

### DIFF
--- a/src/components/task-list.test.tsx
+++ b/src/components/task-list.test.tsx
@@ -7,7 +7,10 @@ expect.extend(matchers);
 import { TaskList } from './task-list';
 
 const defaultQuery = {
-  data: [{ id: '1', title: 'Test', dueAt: null }],
+  data: [
+    { id: '1', title: 'Test 1', dueAt: null, status: 'DONE' },
+    { id: '2', title: 'Test 2', dueAt: null, status: 'TODO' },
+  ],
   isLoading: false,
   error: undefined,
 };
@@ -60,5 +63,10 @@ describe('TaskList', () => {
   it('shows error message when setting due date fails', () => {
     render(<TaskList />);
     expect(screen.getByText('Failed to set due date')).toBeInTheDocument();
+  });
+
+  it('displays completed task ratio', () => {
+    render(<TaskList />);
+    expect(screen.getByText('1/2 completed')).toBeInTheDocument();
   });
 });

--- a/src/components/task-list.tsx
+++ b/src/components/task-list.tsx
@@ -31,6 +31,10 @@ export function TaskList() {
 
   const tasks = api.task.list.useQuery(queryInput);
 
+  const totalTasks = tasks.data?.length ?? 0;
+  const completedTasks =
+    tasks.data?.filter((t) => t.status === "DONE").length ?? 0;
+
   const setDue = api.task.setDueDate.useMutation({
     onSuccess: async () => utils.task.list.invalidate(),
     onError: (e) => toast.error(e.message || "Failed to set due date"),
@@ -53,7 +57,12 @@ export function TaskList() {
 
   return (
     <div className="space-y-3">
-      <TaskFilterTabs value={filter} onChange={setFilter} />
+      <div className="flex items-center justify-between">
+        <TaskFilterTabs value={filter} onChange={setFilter} />
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          {completedTasks}/{totalTasks} completed
+        </p>
+      </div>
       <ul className="space-y-2">
         <AnimatePresence>
           {tasks.data?.map((t) => {


### PR DESCRIPTION
## Summary
- display completed vs total task count in task list

## Testing
- `npm run lint`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cdb0e6cf8832093e28f257832a388