### PR TITLE
feat: animate task filter tabs

### DIFF
--- a/src/components/task-filter-tabs.tsx
+++ b/src/components/task-filter-tabs.tsx
@@ -22,10 +22,10 @@ export function TaskFilterTabs({ value, onChange }: TaskFilterTabsProps) {
           role="tab"
           type="button"
           aria-selected={value === opt.value}
-          className={`rounded border px-3 py-1 text-sm ${
+          className={`bg-transparent px-3 py-1 text-sm border-b-2 transition ${
             value === opt.value
-              ? 'bg-black text-white dark:bg-white dark:text-black'
-              : 'bg-transparent'
+              ? 'border-black dark:border-white'
+              : 'border-transparent'
           }`}
           onClick={() => onChange(opt.value)}
         >


### PR DESCRIPTION
## Summary
- style task filter tabs with transparent backgrounds and bottom border underline
- animate tab underline using tailwind transition utilities

## Testing
- `npm run lint`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cdb15b78083208e1f5d1cf94b22cc