### PR TITLE
feat: add drag-and-drop task ordering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "student-task-scheduler",
       "version": "0.3.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "@next-auth/prisma-adapter": "^1.0.7",
         "@prisma/client": "^5.18.0",
         "@tanstack/react-query": "^5.52.0",
@@ -102,6 +104,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "e2e": "playwright test"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "@next-auth/prisma-adapter": "^1.0.7",
     "@prisma/client": "^5.18.0",
     "@tanstack/react-query": "^5.52.0",
@@ -47,9 +49,9 @@
     "eslint": "8.57.0",
     "eslint-config-next": "14.2.5",
     "jsdom": "^22.1.0",
+    "nodemon": "^3.1.7",
     "postcss": "^8.4.41",
     "prisma": "^5.18.0",
-    "nodemon": "^3.1.7",
     "tailwindcss": "^3.4.10",
     "typescript": "5.7.2",
     "vitest": "^2.0.5"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -99,6 +99,7 @@ model Task {
   notes         String?
   status        TaskStatus @default(TODO)
   priority      Int        @default(0)
+  position      Int        @default(0)
   effortMinutes Int?
   dueAt         DateTime?
   createdAt     DateTime   @default(now())

--- a/src/app/tasks/page.test.tsx
+++ b/src/app/tasks/page.test.tsx
@@ -28,6 +28,7 @@ vi.mock('@/server/api/react', () => ({
       delete: { useMutation: () => ({ mutate: vi.fn() }) },
       updateTitle: { useMutation: () => ({ mutate: vi.fn() }) },
       setStatus: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: { message: 'Failed to update status' } }) },
+      reorder: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },
     },
   },
 }));

--- a/src/components/task-list.test.tsx
+++ b/src/components/task-list.test.tsx
@@ -37,6 +37,7 @@ vi.mock('@/server/api/react', () => ({
       updateTitle: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },
       delete: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },
       setStatus: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },
+      reorder: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },
     },
   },
 }));
@@ -48,7 +49,7 @@ afterEach(() => {
 
 describe('TaskList', () => {
   it('shows loading skeleton when tasks are loading', () => {
-    useQueryMock.mockReturnValueOnce({
+    useQueryMock.mockReturnValue({
       data: [],
       isLoading: true,
       error: undefined,

--- a/src/components/task-list.tsx
+++ b/src/components/task-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { toast } from "react-hot-toast";
@@ -8,6 +8,17 @@ import { api } from "@/server/api/react";
 import { formatLocalDateTime, parseLocalDateTime } from "@/lib/datetime";
 import { TaskListSkeleton } from "./task-list-skeleton";
 import { TaskFilterTabs } from "./task-filter-tabs";
+import {
+  DndContext,
+  closestCenter,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  useSortable,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 
 export function TaskList() {
   const [filter, setFilter] = useState<"all" | "overdue" | "today">("all");
@@ -31,6 +42,14 @@ export function TaskList() {
 
   const tasks = api.task.list.useQuery(queryInput);
 
+  const [items, setItems] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (tasks.data) {
+      setItems(tasks.data.map((t) => t.id));
+    }
+  }, [tasks.data]);
+
   const setDue = api.task.setDueDate.useMutation({
     onSuccess: async () => utils.task.list.invalidate(),
     onError: (e) => toast.error(e.message || "Failed to set due date"),
@@ -51,100 +70,141 @@ export function TaskList() {
     onError: (e) => toast.error(e.message || "Failed to update status"),
   });
 
+  const reorder = api.task.reorder.useMutation({
+    onSuccess: async () => utils.task.list.invalidate(),
+    onError: (e) => toast.error(e.message || "Failed to reorder tasks"),
+  });
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    setItems((prev) => {
+      const oldIndex = prev.indexOf(active.id as string);
+      const newIndex = prev.indexOf(over.id as string);
+      const newItems = arrayMove(prev, oldIndex, newIndex);
+      reorder.mutate({ ids: newItems });
+      return newItems;
+    });
+  };
+
+  const taskData = tasks.data;
+  const orderedTasks = React.useMemo(() => {
+    if (!taskData) return [] as typeof taskData;
+    const map = new Map(taskData.map((t) => [t.id, t]));
+    return items.map((id) => map.get(id)).filter(Boolean) as typeof taskData;
+  }, [taskData, items]);
+
+  const TaskItem = ({ t }: { t: (typeof orderedTasks)[number] }) => {
+    const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: t.id });
+    const style = {
+      transform: CSS.Transform.toString(transform),
+      transition,
+    };
+    const overdue = t.dueAt ? new Date(t.dueAt) < new Date() : false;
+    const done = t.status === "DONE";
+    return (
+      <motion.li
+        ref={setNodeRef}
+        style={style}
+        {...attributes}
+        {...listeners}
+        key={t.id}
+        initial={{ opacity: 0, y: -8 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: 8 }}
+        transition={{ duration: 0.15 }}
+        layout
+        className={`flex items-center justify-between rounded border px-3 py-2 ${
+          overdue
+            ? "border-red-500 bg-red-50 text-red-800 dark:bg-red-950 dark:text-red-200"
+            : ""
+        }`}
+      >
+        <div className="flex items-start gap-2 flex-1">
+          <input
+            type="checkbox"
+            className="mt-1"
+            checked={done}
+            onChange={() =>
+              setStatus.mutate({ id: t.id, status: done ? "TODO" : "DONE" })
+            }
+            aria-label={done ? "Mark as todo" : "Mark as done"}
+          />
+          <div className="flex flex-col gap-1 flex-1">
+            <input
+              type="text"
+              defaultValue={t.title}
+              className={`font-medium rounded border px-2 py-1 ${
+                done ? "line-through opacity-60" : ""
+              }`}
+              onBlur={(e) => rename.mutate({ id: t.id, title: e.currentTarget.value })}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") e.currentTarget.blur();
+              }}
+            />
+            <div className="flex items-center gap-2 text-xs opacity-80">
+              <label>Due:</label>
+              <input
+                type="datetime-local"
+                className="rounded border px-2 py-1"
+                value={t.dueAt ? formatLocalDateTime(new Date(t.dueAt)) : ""}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  const date = v ? parseLocalDateTime(v) : null;
+                  setDue.mutate({ id: t.id, dueAt: date });
+                }}
+              />
+              {t.dueAt && (
+                <Button
+                  variant="secondary"
+                  className="underline bg-transparent border-0 px-0 py-0"
+                  onClick={() => setDue.mutate({ id: t.id, dueAt: null })}
+                >
+                  Clear
+                </Button>
+              )}
+              {t.dueAt && (
+                <span className="ml-2">
+                  {overdue ? "Overdue" : `Due ${new Date(t.dueAt).toLocaleString()}`}
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+        <Button
+          variant="danger"
+          className="text-sm underline bg-transparent px-0 py-0 text-red-600"
+          onClick={() => {
+            if (confirm("Are you sure you want to delete this task?")) {
+              del.mutate({ id: t.id });
+            }
+          }}
+        >
+          Delete
+        </Button>
+      </motion.li>
+    );
+  };
+
   return (
     <div className="space-y-3">
       <TaskFilterTabs value={filter} onChange={setFilter} />
-      <ul className="space-y-2">
-        <AnimatePresence>
-          {tasks.data?.map((t) => {
-            const overdue = t.dueAt ? new Date(t.dueAt) < new Date() : false;
-            const done = t.status === "DONE";
-            return (
-              <motion.li
-                key={t.id}
-                initial={{ opacity: 0, y: -8 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: 8 }}
-                transition={{ duration: 0.15 }}
-                layout
-                className={`flex items-center justify-between rounded border px-3 py-2 ${
-                  overdue
-                    ? "border-red-500 bg-red-50 text-red-800 dark:bg-red-950 dark:text-red-200"
-                    : ""
-                }`}
-              >
-                <div className="flex items-start gap-2 flex-1">
-                  <input
-                    type="checkbox"
-                    className="mt-1"
-                    checked={done}
-                    onChange={() =>
-                      setStatus.mutate({ id: t.id, status: done ? "TODO" : "DONE" })
-                    }
-                    aria-label={done ? "Mark as todo" : "Mark as done"}
-                  />
-                  <div className="flex flex-col gap-1 flex-1">
-                    <input
-                      type="text"
-                      defaultValue={t.title}
-                      className={`font-medium rounded border px-2 py-1 ${
-                        done ? "line-through opacity-60" : ""
-                      }`}
-                      onBlur={(e) => rename.mutate({ id: t.id, title: e.currentTarget.value })}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") e.currentTarget.blur();
-                      }}
-                    />
-                    <div className="flex items-center gap-2 text-xs opacity-80">
-                      <label>Due:</label>
-                      <input
-                        type="datetime-local"
-                        className="rounded border px-2 py-1"
-                        value={t.dueAt ? formatLocalDateTime(new Date(t.dueAt)) : ""}
-                        onChange={(e) => {
-                          const v = e.target.value;
-                          const date = v ? parseLocalDateTime(v) : null;
-                          setDue.mutate({ id: t.id, dueAt: date });
-                        }}
-                      />
-                      {t.dueAt && (
-                        <Button
-                          variant="secondary"
-                          className="underline bg-transparent border-0 px-0 py-0"
-                          onClick={() => setDue.mutate({ id: t.id, dueAt: null })}
-                        >
-                          Clear
-                        </Button>
-                      )}
-                      {t.dueAt && (
-                        <span className="ml-2">
-                          {overdue ? "Overdue" : `Due ${new Date(t.dueAt).toLocaleString()}`}
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                </div>
-                <Button
-                  variant="danger"
-                  className="text-sm underline bg-transparent px-0 py-0 text-red-600"
-                  onClick={() => {
-                    if (confirm("Are you sure you want to delete this task?")) {
-                      del.mutate({ id: t.id });
-                    }
-                  }}
-                >
-                  Delete
-                </Button>
-              </motion.li>
-            );
-          })}
-        </AnimatePresence>
+      <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext items={items}>
+          <ul className="space-y-2">
+            <AnimatePresence>
+              {orderedTasks.map((t) => (
+                <TaskItem key={t.id} t={t} />
+              ))}
+            </AnimatePresence>
 
-        {tasks.isLoading && <TaskListSkeleton />}
-        {!tasks.isLoading && (tasks.data?.length ?? 0) === 0 && (
-          <li className="opacity-60">No tasks.</li>
-        )}
-      </ul>
+            {tasks.isLoading && <TaskListSkeleton />}
+            {!tasks.isLoading && orderedTasks.length === 0 && (
+              <li className="opacity-60">No tasks.</li>
+            )}
+          </ul>
+        </SortableContext>
+      </DndContext>
 
       {tasks.error && (
         <p role="alert" className="text-red-500">

--- a/src/server/api/routers/task.test.ts
+++ b/src/server/api/routers/task.test.ts
@@ -3,7 +3,14 @@ import { TaskStatus } from '@prisma/client';
 import { taskRouter } from './task';
 
 // In-memory store to simulate DB
-type T = { id: string; title: string; createdAt: Date; dueAt?: Date | null; status: TaskStatus };
+type T = {
+  id: string;
+  title: string;
+  createdAt: Date;
+  dueAt?: Date | null;
+  status: TaskStatus;
+  position: number;
+};
 let store: T[] = [];
 let idSeq = 0;
 
@@ -11,6 +18,11 @@ let idSeq = 0;
 vi.mock('@/server/db', () => {
   return {
     db: {
+      $transaction: async (ops: any[]) => {
+        for (const op of ops) {
+          await op;
+        }
+      },
       task: {
         findMany: vi.fn(
           async (
@@ -33,41 +45,33 @@ vi.mock('@/server/db', () => {
                 return true;
               });
             }
-            // Very light ordering: dueAt asc (nulls last), then createdAt desc
-            result.sort((a, b) => {
-              const ad = a.dueAt ?? null;
-              const bd = b.dueAt ?? null;
-              if (ad === null && bd === null) {
-                return b.createdAt.getTime() - a.createdAt.getTime();
-              }
-              if (ad === null) return 1;
-              if (bd === null) return -1;
-              const cmp = ad.getTime() - bd.getTime();
-              if (cmp !== 0) return cmp;
-              return b.createdAt.getTime() - a.createdAt.getTime();
-            });
+            // Order by position asc
+            result.sort((a, b) => a.position - b.position);
             return result.map((t) => ({
               id: t.id,
               title: t.title,
               createdAt: t.createdAt,
               dueAt: t.dueAt ?? null,
               status: t.status,
+              position: t.position,
             }));
           }
         ),
         create: vi.fn(
-          async ({ data }: { data: { title: string; dueAt?: Date | null } }) => {
+          async ({ data }: { data: { title: string; dueAt?: Date | null; position: number } }) => {
             const item: T = {
               id: `t_${++idSeq}`,
               title: data.title,
               createdAt: new Date(),
               dueAt: data.dueAt ?? null,
               status: TaskStatus.TODO,
+              position: data.position,
             };
             store.push(item);
             return item;
           }
         ),
+        aggregate: vi.fn(async () => ({ _max: { position: store.length ? store[store.length - 1].position : null } })),
         update: vi.fn(
           async ({ where, data }: { where: { id: string }; data: Partial<T> }) => {
             const idx = store.findIndex((t) => t.id === where.id);
@@ -117,6 +121,15 @@ describe('taskRouter (no auth)', () => {
     await caller.delete({ id: created.id });
     const list2 = await caller.list();
     expect(list2).toHaveLength(0);
+  });
+
+  it('reorders tasks', async () => {
+    const caller = taskRouter.createCaller({});
+    const t1 = await caller.create({ title: 'First' });
+    const t2 = await caller.create({ title: 'Second' });
+    await caller.reorder({ ids: [t2.id, t1.id] });
+    const list = await caller.list();
+    expect(list.map((t) => t.id)).toEqual([t2.id, t1.id]);
   });
 
   it('updates a task title', async () => {


### PR DESCRIPTION
## Summary
- add dnd-kit for sortable task list
- persist and reorder task positions via new API
- store task position in Prisma schema

## Testing
- `npm run lint`
- `npx vitest run src/server/api/routers/task.test.ts`
- `npx vitest run src/components/task-list.test.tsx`
- `npx vitest run src/app/tasks/page.test.tsx` *(fails: JavaScript heap out of memory)*
- `npx prisma generate`
- `npx prisma db push` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_689cdb27ecb08320aeb41a62b89613b5