### PR TITLE
feat: support task status dropdown

### DIFF
--- a/src/components/task-list.test.tsx
+++ b/src/components/task-list.test.tsx
@@ -35,6 +35,7 @@ const defaultQuery = {
   error: undefined,
 };
 const useQueryMock = vi.fn().mockReturnValue(defaultQuery);
+const setStatusMock = vi.fn();
 
 vi.mock('@/server/api/react', () => ({
   api: {
@@ -60,7 +61,7 @@ vi.mock('@/server/api/react', () => ({
       },
       updateTitle: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },
       delete: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },
-      setStatus: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },
+      setStatus: { useMutation: () => ({ mutate: setStatusMock, isPending: false, error: undefined }) },
       reorder: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },
     },
   },
@@ -70,6 +71,7 @@ afterEach(() => {
   cleanup();
   useQueryMock.mockReturnValue(defaultQuery);
   sortableItemsCalls.length = 0;
+  setStatusMock.mockClear();
 });
 
 describe('TaskList', () => {
@@ -145,5 +147,14 @@ describe('TaskList', () => {
     expect(screen.getByText('Gamma')).toBeInTheDocument();
     expect(screen.queryByText('Alpha')).not.toBeInTheDocument();
     expect(screen.queryByText('Beta')).not.toBeInTheDocument();
+  });
+
+  it('updates task status via dropdown', () => {
+    render(<TaskList />);
+    const selects = screen.getAllByLabelText('Change status');
+    fireEvent.change(selects[1], { target: { value: 'IN_PROGRESS' } });
+    expect(setStatusMock).toHaveBeenCalledWith({ id: '2', status: 'IN_PROGRESS' });
+    fireEvent.change(selects[1], { target: { value: 'CANCELLED' } });
+    expect(setStatusMock).toHaveBeenCalledWith({ id: '2', status: 'CANCELLED' });
   });
 });

--- a/src/components/task-list.tsx
+++ b/src/components/task-list.tsx
@@ -177,16 +177,23 @@ export function TaskList() {
           >
             <GripVertical className="h-4 w-4" />
           </button>
-          <input
-            type="checkbox"
-            className="mt-1"
-            checked={done}
-            onChange={() =>
-              setStatus.mutate({ id: t.id, status: done ? "TODO" : "DONE" })
+          <select
+            className="mt-1 rounded border bg-transparent text-xs"
+            value={t.status}
+            onChange={(e) =>
+              setStatus.mutate({
+                id: t.id,
+                status: e.currentTarget.value as any,
+              })
             }
-            aria-label={done ? "Mark as todo" : "Mark as done"}
+            aria-label="Change status"
             onClick={(e) => e.stopPropagation()}
-          />
+          >
+            <option value="TODO">TODO</option>
+            <option value="IN_PROGRESS">IN_PROGRESS</option>
+            <option value="DONE">DONE</option>
+            <option value="CANCELLED">CANCELLED</option>
+          </select>
           <div className="flex flex-col gap-1 flex-1">
             <div className="flex flex-wrap items-center gap-2">
               <span className={`font-medium ${done ? "line-through opacity-60" : ""}`}>

--- a/src/server/api/routers/task.test.ts
+++ b/src/server/api/routers/task.test.ts
@@ -51,3 +51,22 @@ describe('taskRouter.reorder', () => {
     expect(hoisted.update).toHaveBeenCalledWith({ where: { id: 'c' }, data: { position: 2 } });
   });
 });
+
+describe('taskRouter.setStatus', () => {
+  beforeEach(() => {
+    hoisted.update.mockClear();
+  });
+
+  it.each([
+    'TODO',
+    'IN_PROGRESS',
+    'DONE',
+    'CANCELLED',
+  ] as const)('updates status to %s', async (status) => {
+    await taskRouter.createCaller({}).setStatus({ id: '1', status });
+    expect(hoisted.update).toHaveBeenCalledWith({
+      where: { id: '1' },
+      data: { status },
+    });
+  });
+});

--- a/src/server/api/routers/task.ts
+++ b/src/server/api/routers/task.ts
@@ -127,10 +127,16 @@ export const taskRouter = router({
     }),
   setStatus: publicProcedure
     .input(
-      z.object({ id: z.string().min(1), status: z.nativeEnum(TaskStatus) })
+      z.object({
+        id: z.string().min(1),
+        status: z.enum(["TODO", "IN_PROGRESS", "DONE", "CANCELLED"]),
+      })
     )
     .mutation(async ({ input }) => {
-      return (db as any).task.update({ where: { id: input.id }, data: { status: input.status } });
+      return (db as any).task.update({
+        where: { id: input.id },
+        data: { status: input.status as TaskStatus },
+      });
     }),
   delete: publicProcedure
     .input(z.object({ id: z.string().min(1) }))


### PR DESCRIPTION
## Summary
- support full task status selection in list UI
- validate and persist all task statuses on server
- add coverage for status transitions

## Testing
- `npm run lint`
- `CI=true npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a3e272ba948320b60fd17700e7743c