### PR TITLE
refactor: type db operations

### DIFF
--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -1,4 +1,10 @@
 import { PrismaClient } from '@prisma/client';
-const globalForPrisma=globalThis as unknown as {prisma:PrismaClient|undefined};
-export const db=globalForPrisma.prisma ?? new PrismaClient();
-if(process.env.NODE_ENV!=='production') globalForPrisma.prisma=db;
+
+const globalForPrisma = globalThis as unknown as {
+  prisma?: PrismaClient;
+};
+
+export const db: PrismaClient =
+  globalForPrisma.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = db;


### PR DESCRIPTION
## Summary
- type due date ordering and DB calls in task router
- export typed Prisma client instance

## Testing
- `npm run lint`
- `npm test` *(fails: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e2b1780c83208e563767c60004b4