### PR TITLE
style: format app router imports

### DIFF
--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -2,5 +2,11 @@ import { router } from './trpc';
 import { taskRouter } from './routers/task';
 import { eventRouter } from './routers/event';
 import { focusRouter } from './routers/focus';
-export const appRouter=router({task:taskRouter, event:eventRouter, focus:focusRouter});
-export type AppRouter=typeof appRouter;
+
+export const appRouter = router({
+  task: taskRouter,
+  event: eventRouter,
+  focus: focusRouter,
+});
+
+export type AppRouter = typeof appRouter;


### PR DESCRIPTION
## Summary
- format imports in app router and expand router definition

## Testing
- `npm run lint`
- `CI=true npm test` *(fails: test command did not finish)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fecf244083209da80a314a902adc