### PR TITLE
refactor: type-safe db usage in event and focus routers

### DIFF
--- a/src/server/api/routers/event.ts
+++ b/src/server/api/routers/event.ts
@@ -2,34 +2,34 @@ import { z } from 'zod';
 import { TRPCError } from '@trpc/server';
 import { publicProcedure, router } from '../trpc';
 import { db } from '@/server/db';
-import { findNonOverlappingSlot } from '@/lib/scheduling';
+import { findNonOverlappingSlot, Interval } from '@/lib/scheduling';
+import type { Event as EventModel, Prisma } from '@prisma/client';
 
 export const eventRouter = router({
   listRange: publicProcedure
     .input(z.object({ start: z.date().optional(), end: z.date().optional() }).optional())
     .query(async ({ input }) => {
-      const where: any = {};
+      const where: Prisma.EventWhereInput = {};
       if (input?.start && input?.end) {
         where.OR = [
           { startAt: { gte: input.start, lt: input.end } },
           { endAt: { gt: input.start, lte: input.end } },
         ];
       }
-      return (db as any).event.findMany({ where });
+      return db.event.findMany({ where });
     }),
   schedule: publicProcedure
     .input(z.object({ taskId: z.string().min(1), startAt: z.date(), durationMinutes: z.number().int().positive() }))
     .mutation(async ({ input }) => {
       const duration = input.durationMinutes;
       const desiredStart = input.startAt;
-      const desiredEnd = new Date(desiredStart.getTime() + duration * 60_000);
 
       const sameDayStart = new Date(desiredStart);
       sameDayStart.setHours(0, 0, 0, 0);
       const sameDayEnd = new Date(desiredStart);
       sameDayEnd.setHours(23, 59, 59, 999);
 
-      const existing = await (db as any).event.findMany({
+      const existing: EventModel[] = await db.event.findMany({
         where: {
           // Consider same day events for overlap avoidance
           OR: [
@@ -39,12 +39,14 @@ export const eventRouter = router({
         },
       });
 
+      const intervals: Interval[] = existing.map((e) => ({ startAt: new Date(e.startAt), endAt: new Date(e.endAt) }));
+
       const slot = findNonOverlappingSlot({
         desiredStart,
         durationMinutes: duration,
         dayWindowStartHour: 8,
         dayWindowEndHour: 18,
-        existing: existing.map((e: any) => ({ startAt: new Date(e.startAt), endAt: new Date(e.endAt) })),
+        existing: intervals,
         stepMinutes: 15,
       });
 
@@ -52,7 +54,7 @@ export const eventRouter = router({
         throw new TRPCError({ code: 'CONFLICT', message: 'No available time slot without overlap' });
       }
 
-      return (db as any).event.create({ data: { taskId: input.taskId, startAt: slot.startAt, endAt: slot.endAt } });
+      return db.event.create({ data: { taskId: input.taskId, startAt: slot.startAt, endAt: slot.endAt } });
     }),
   move: publicProcedure
     .input(z.object({ eventId: z.string().min(1), startAt: z.date(), endAt: z.date() }))
@@ -66,7 +68,7 @@ export const eventRouter = router({
       const sameDayEnd = new Date(input.startAt);
       sameDayEnd.setHours(23, 59, 59, 999);
 
-      const existing = await (db as any).event.findMany({
+      const existing: EventModel[] = await db.event.findMany({
         where: {
           id: { not: input.eventId },
           OR: [
@@ -76,25 +78,26 @@ export const eventRouter = router({
         },
       });
 
-      const overlaps = existing.some((e: any) => input.startAt < new Date(e.endAt) && new Date(e.startAt) < input.endAt);
+      const overlaps = existing.some((e) => input.startAt < e.endAt && e.startAt < input.endAt);
       if (overlaps) {
         // Try to reslot forward on same day using the requested duration
         const durationMin = Math.round((input.endAt.getTime() - input.startAt.getTime()) / 60000);
+        const intervals: Interval[] = existing.map((e) => ({ startAt: e.startAt, endAt: e.endAt }));
         const slot = findNonOverlappingSlot({
           desiredStart: input.startAt,
           durationMinutes: durationMin,
           dayWindowStartHour: 8,
           dayWindowEndHour: 18,
-          existing: existing.map((e: any) => ({ startAt: new Date(e.startAt), endAt: new Date(e.endAt) })),
+          existing: intervals,
           stepMinutes: 15,
         });
         if (!slot) {
           throw new TRPCError({ code: 'CONFLICT', message: 'Cannot move without overlapping any event' });
         }
-        return (db as any).event.update({ where: { id: input.eventId }, data: { startAt: slot.startAt, endAt: slot.endAt } });
+        return db.event.update({ where: { id: input.eventId }, data: { startAt: slot.startAt, endAt: slot.endAt } });
       }
 
-      return (db as any).event.update({ where: { id: input.eventId }, data: { startAt: input.startAt, endAt: input.endAt } });
+      return db.event.update({ where: { id: input.eventId }, data: { startAt: input.startAt, endAt: input.endAt } });
     }),
 });
 

--- a/src/server/api/routers/focus.ts
+++ b/src/server/api/routers/focus.ts
@@ -1,21 +1,25 @@
 import { z } from 'zod';
 import { router, publicProcedure } from '../trpc';
 import { db } from '@/server/db';
+import type { TaskTimeLog } from '@prisma/client';
 
 export const focusRouter = router({
   start: publicProcedure
     .input(z.object({ taskId: z.string().min(1) }))
     .mutation(async ({ input }) => {
       // End any existing open log for any task
-      await (db as any).taskTimeLog.updateMany({ where: { endedAt: null }, data: { endedAt: new Date() } });
-      return (db as any).taskTimeLog.create({ data: { taskId: input.taskId, startedAt: new Date(), endedAt: null } });
+      await db.taskTimeLog.updateMany({ where: { endedAt: null }, data: { endedAt: new Date() } });
+      return db.taskTimeLog.create({ data: { taskId: input.taskId, startedAt: new Date(), endedAt: null } });
     }),
   stop: publicProcedure
     .input(z.object({ taskId: z.string().min(1) }))
     .mutation(async ({ input }) => {
-      const open = await (db as any).taskTimeLog.findFirst({ where: { taskId: input.taskId, endedAt: null }, orderBy: { startedAt: 'desc' } });
+      const open: TaskTimeLog | null = await db.taskTimeLog.findFirst({
+        where: { taskId: input.taskId, endedAt: null },
+        orderBy: { startedAt: 'desc' },
+      });
       if (!open) return { ok: true };
-      await (db as any).taskTimeLog.update({ where: { id: open.id }, data: { endedAt: new Date() } });
+      await db.taskTimeLog.update({ where: { id: open.id }, data: { endedAt: new Date() } });
       return { ok: true };
     }),
 });


### PR DESCRIPTION
## Summary
- remove `any` casts around `db` usage
- type event queries using Prisma interfaces
- tighten focus router typing with `TaskTimeLog`

## Testing
- `npm run lint`
- `CI=true npm test` *(fails: Unable to find tRPC Context, app router not mounted, worker out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fee0076083209bc804a59a4a923a