### PR TITLE
refactor: type tasks using RouterOutputs

### DIFF
--- a/src/components/task-list.test.tsx
+++ b/src/components/task-list.test.tsx
@@ -5,6 +5,9 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import * as matchers from '@testing-library/jest-dom/matchers';
 expect.extend(matchers);
 import { TaskList } from './task-list';
+import type { RouterOutputs } from '@/server/api/root';
+
+type Task = RouterOutputs['task']['list'][number];
 
 // Capture items passed to SortableContext so we can assert compaction
 const sortableItemsCalls: unknown[][] = [];
@@ -121,7 +124,7 @@ describe('TaskList', () => {
 
   it('displays archived count', () => {
     // Return DONE only for archive filter, everything for others
-    useQueryMock.mockImplementation((input?: any) => {
+    useQueryMock.mockImplementation((input?: unknown) => {
       const base = {
         data: [
           { id: '1', title: 'Test 1', dueAt: null, status: 'DONE', subject: 'math' },
@@ -131,7 +134,7 @@ describe('TaskList', () => {
         error: undefined,
       };
       if (input && input.filter === 'archive') {
-        return { data: base.data.filter((t: any) => t.status === 'DONE'), isLoading: false, error: undefined };
+        return { data: base.data.filter((t: Task) => t.status === 'DONE'), isLoading: false, error: undefined };
       }
       return base;
     });

--- a/src/components/task-modal.test.tsx
+++ b/src/components/task-modal.test.tsx
@@ -4,6 +4,9 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as matchers from '@testing-library/jest-dom/matchers';
 import { TaskModal } from './task-modal';
+import type { RouterOutputs } from '@/server/api/root';
+
+type Task = RouterOutputs['task']['list'][number];
 
 expect.extend(matchers);
 
@@ -17,6 +20,7 @@ vi.mock('@/server/api/react', () => ({
       create: { useMutation: () => ({ mutate: (...a: unknown[]) => mutateCreate(...a), isPending: false }) },
       update: { useMutation: () => ({ mutate: (...a: unknown[]) => mutateUpdate(...a), isPending: false }) },
       delete: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      setStatus: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
     },
   },
 }));
@@ -28,9 +32,9 @@ describe('TaskModal due date editing', () => {
   });
 
   it('adds a due date to a task that previously had none when saving', () => {
-    const task = { id: 't1', title: 'Write essay', subject: null, notes: null, dueAt: null };
+    const task = { id: 't1', title: 'Write essay', subject: null, notes: null, dueAt: null } as Task;
     render(
-      <TaskModal open mode="edit" onClose={() => {}} task={task as any} />
+      <TaskModal open mode="edit" onClose={() => {}} task={task} />
     );
 
     // Enable due date
@@ -46,7 +50,7 @@ describe('TaskModal due date editing', () => {
     fireEvent.click(screen.getByText('Save'));
 
     expect(mutateUpdate).toHaveBeenCalledTimes(1);
-    const arg = mutateUpdate.mock.calls[0][0] as any;
+    const arg = mutateUpdate.mock.calls[0][0] as { id: string; dueAt: Date };
     expect(arg.id).toBe('t1');
     expect(arg.dueAt).toBeInstanceOf(Date);
     // The local time parsed should match the chosen fields

--- a/src/components/task-modal.tsx
+++ b/src/components/task-modal.tsx
@@ -2,27 +2,21 @@
 import React, { useEffect, useState } from "react";
 import { Modal } from "@/components/ui/modal";
 import { Button } from "@/components/ui/button";
-import { StatusDropdown, type TaskStatus } from "@/components/status-dropdown";
+import { StatusDropdown } from "@/components/status-dropdown";
 import { api } from "@/server/api/react";
 import { toast } from "react-hot-toast";
 import { formatLocalDateTime, parseLocalDateTime, defaultEndOfToday } from "@/lib/datetime";
 
-type BaseTask = {
-  id: string;
-  title: string;
-  subject: string | null;
-  notes: string | null;
-  dueAt: Date | string | null;
-  status?: TaskStatus;
-  priority?: "LOW" | "MEDIUM" | "HIGH";
-};
+import type { RouterOutputs } from "@/server/api/root";
+
+type Task = RouterOutputs["task"]["list"][number];
 
 interface TaskModalProps {
   open: boolean;
   mode: "create" | "edit";
   onClose: () => void;
   // For edit mode, pass the task snapshot
-  task?: BaseTask;
+  task?: Task;
   initialTitle?: string;
   initialDueAt?: Date | null;
   onDraftDueChange?: (dueAt: Date | null) => void;
@@ -45,9 +39,9 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
       setTitle(task.title);
       setSubject(task.subject ?? "");
       setNotes(task.notes ?? "");
-      setPriority((task as any).priority ?? "MEDIUM");
+      setPriority(task.priority ?? "MEDIUM");
       const hasDue = task.dueAt != null;
-      setDue(hasDue ? formatLocalDateTime(new Date(task.dueAt as any)) : "");
+      setDue(hasDue ? formatLocalDateTime(new Date(task.dueAt!)) : "");
       setDueEnabled(hasDue);
     } else {
       setTitle(initialTitle ?? "");
@@ -143,9 +137,9 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
           <div className="flex items-center justify-between">
             <span className="text-xs uppercase tracking-wide opacity-60">Status</span>
             <StatusDropdown
-              value={(task.status ?? "TODO") as TaskStatus}
+              value={task.status ?? "TODO"}
               onChange={(next) => {
-                setStatus.mutate({ id: task.id, status: next as any });
+                setStatus.mutate({ id: task.id, status: next });
                 if (next === "DONE") onClose();
               }}
             />
@@ -207,7 +201,7 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
           <select
             className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
             value={priority}
-            onChange={(e) => setPriority(e.target.value as any)}
+            onChange={(e) => setPriority(e.target.value as Task["priority"])}
           >
             <option value="LOW">Low</option>
             <option value="MEDIUM">Medium</option>

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -1,6 +1,9 @@
+import { inferRouterOutputs } from '@trpc/server';
 import { router } from './trpc';
 import { taskRouter } from './routers/task';
 import { eventRouter } from './routers/event';
 import { focusRouter } from './routers/focus';
-export const appRouter=router({task:taskRouter, event:eventRouter, focus:focusRouter});
-export type AppRouter=typeof appRouter;
+
+export const appRouter = router({ task: taskRouter, event: eventRouter, focus: focusRouter });
+export type AppRouter = typeof appRouter;
+export type RouterOutputs = inferRouterOutputs<AppRouter>;


### PR DESCRIPTION
## Summary
- use RouterOutputs to define a Task type for task components
- replace `any` task casts in TaskList and TaskModal
- export RouterOutputs from API root

## Testing
- `npm run lint`
- `CI=true npm test` *(fails: Unable to find tRPC Context; invariant expected app router to be mounted)*

------
https://chatgpt.com/codex/tasks/task_e_68a4feed3e7c8320bc2af8898ed12053