### PR TITLE
test: add task e2e spec

### DIFF
--- a/e2e/tasks.spec.ts
+++ b/e2e/tasks.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+
+test('user can create, edit, and delete a task', async ({ page }) => {
+  const title = `Playwright Task ${Date.now()}`;
+  const updated = `${title} Updated`;
+
+  await page.goto('/');
+
+  const input = page.getByPlaceholder('Add a task…');
+  await input.fill(title);
+  await page.keyboard.press('Enter');
+  await expect(page.getByText(title)).toBeVisible();
+
+  await page.getByText(title).click();
+  const modal = page.getByRole('dialog');
+  await expect(modal).toBeVisible();
+  await modal.getByLabel('Title').fill(updated);
+  await modal.getByRole('button', { name: 'Save' }).click();
+  await expect(page.getByText(updated)).toBeVisible();
+
+  await page.getByText(updated).click();
+  const editModal = page.getByRole('dialog');
+  await expect(editModal).toBeVisible();
+  await editModal.getByRole('button', { name: 'Delete' }).click();
+  await expect(page.getByText(updated)).toHaveCount(0);
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+  webServer: {
+    command: 'npm run dev',
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+  },
+});


### PR DESCRIPTION
## Summary
- add Playwright config pointing to e2e specs
- cover creating, editing, and deleting a task

## Testing
- `npm run lint`
- `CI=true npm test` *(fails: no tests executed?)*
- `npm run e2e` *(fails: missing Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ff08df488320be8575b21e914e2a