### PR TITLE
refactor: import useDndMonitor

### DIFF
--- a/src/components/calendar/CalendarGrid.tsx
+++ b/src/components/calendar/CalendarGrid.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from 'react';
-import { useDraggable, useDroppable } from '@dnd-kit/core';
+import { useDraggable, useDroppable, useDndMonitor } from '@dnd-kit/core';
 
 type ViewMode = 'day' | 'week' | 'month';
 
@@ -142,9 +142,6 @@ function ResizableEventBox({ id, title, style, pxPerMin, onResizeDelta }: { id: 
   }, [id, onResizeDelta, pxPerMin]);
 
   // Using window-level dnd monitor to detect when the specific handle ends dragging
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const { useDndMonitor } = require('@dnd-kit/core');
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   useDndMonitor({
     onDragEnd: (event: any) => {
       const activeId = String(event.active?.id ?? '');


### PR DESCRIPTION
## Summary
- switch CalendarGrid to top-level `useDndMonitor` import

## Testing
- `npm run lint`
- `CI=true npm test` *(fails: vitest run hangs)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fefe99808320a236101a498e7e7b