### PR TITLE
feat: handle stats page query errors

### DIFF
--- a/src/app/stats/page.test.tsx
+++ b/src/app/stats/page.test.tsx
@@ -3,30 +3,40 @@ import React from 'react';
 import { render, screen, cleanup } from '@testing-library/react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import * as matchers from '@testing-library/jest-dom/matchers';
-expect.extend(matchers);
-import StatsPage from './page';
 
 vi.mock('@/server/api/react', () => ({
   api: {
     task: {
       list: {
-        useQuery: () => ({
-          data: [
-            { id: '1', status: 'TODO', subject: 'Math' },
-            { id: '2', status: 'DONE', subject: 'Science' },
-            { id: '3', status: 'DONE', subject: 'Math' },
-          ],
-          isLoading: false,
-        }),
+        useQuery: vi.fn(),
       },
     },
   },
 }));
 
-afterEach(() => cleanup());
+import { api } from '@/server/api/react';
+import StatsPage from './page';
+
+const useQueryMock = api.task.list.useQuery as ReturnType<typeof vi.fn>;
+
+expect.extend(matchers);
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
 
 describe('StatsPage', () => {
   it('renders summary metrics', () => {
+    useQueryMock.mockReturnValue({
+      data: [
+        { id: '1', status: 'TODO', subject: 'Math' },
+        { id: '2', status: 'DONE', subject: 'Science' },
+        { id: '3', status: 'DONE', subject: 'Math' },
+      ],
+      isLoading: false,
+    });
+
     render(<StatsPage />);
     expect(screen.getByText('Total Tasks: 3')).toBeInTheDocument();
     expect(screen.getByText('Completion Rate: 67%')).toBeInTheDocument();
@@ -34,5 +44,16 @@ describe('StatsPage', () => {
     expect(screen.getByText('DONE: 2')).toBeInTheDocument();
     expect(screen.getByText('Math: 2')).toBeInTheDocument();
     expect(screen.getByText('Science: 1')).toBeInTheDocument();
+  });
+
+  it('renders error message when query fails', () => {
+    useQueryMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: new Error('oops'),
+    });
+
+    render(<StatsPage />);
+    expect(screen.getByText('Error loading tasks')).toBeInTheDocument();
   });
 });

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -14,8 +14,9 @@ import {
 } from "recharts";
 
 export default function StatsPage() {
-  const { data: tasks = [], isLoading } = api.task.list.useQuery();
+  const { data: tasks = [], isLoading, error } = api.task.list.useQuery();
 
+  if (error) return <main>Error loading tasks</main>;
   if (isLoading) return <main>Loading...</main>;
 
   const total = tasks.length;


### PR DESCRIPTION
## Summary
- show error message on stats page when task list query fails
- test error handling for stats page query

## Testing
- `npm run lint`
- `npx vitest run --reporter=basic src/app/stats/page.test.tsx`
- `npx vitest run --reporter=basic` *(fails: process hung)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ff01972c83209d1d62984cf40530