### PR TITLE
feat: theme-aware stats charts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,3 +56,8 @@
 - Start with `npm install` and env setup.
 - Validate with `npm run lint` and `npm test` before commits.
 - Keep PRs small and incremental; prefer typed, tRPC-first changes.
+
+## Stats
+- The stats page adapts charts for light and dark themes using `next-themes`.
+- Maintain parallel color palettes for both themes and update tests when modifying visuals.
+- Visual regression snapshots live in `src/app/stats/page.test.tsx` and should cover light and dark modes.

--- a/src/app/stats/__snapshots__/page.test.tsx.snap
+++ b/src/app/stats/__snapshots__/page.test.tsx.snap
@@ -1,0 +1,161 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`StatsPage > visual regression > matches dark theme snapshot 1`] = `
+<div>
+  <main
+    class="space-y-6 text-neutral-900 dark:text-neutral-100"
+  >
+    <header>
+      <h1
+        class="text-2xl font-semibold"
+      >
+        Task Statistics
+      </h1>
+    </header>
+    <section
+      class="space-y-2"
+    >
+      <p>
+        Total Tasks: 
+        2
+      </p>
+      <p>
+        Completion Rate: 
+        50
+        %
+      </p>
+    </section>
+    <section
+      class="space-y-2"
+    >
+      <h2
+        class="text-xl font-medium"
+      >
+        By Status
+      </h2>
+      <ul>
+        <li>
+          TODO
+          : 
+          1
+        </li>
+        <li>
+          DONE
+          : 
+          1
+        </li>
+      </ul>
+      <div
+        data="[object Object],[object Object]"
+        height="200"
+        width="400"
+      />
+    </section>
+    <section
+      class="space-y-2"
+    >
+      <h2
+        class="text-xl font-medium"
+      >
+        By Subject
+      </h2>
+      <ul>
+        <li>
+          Math
+          : 
+          1
+        </li>
+        <li>
+          Science
+          : 
+          1
+        </li>
+      </ul>
+      <div
+        height="200"
+        width="400"
+      />
+    </section>
+  </main>
+</div>
+`;
+
+exports[`StatsPage > visual regression > matches light theme snapshot 1`] = `
+<div>
+  <main
+    class="space-y-6 text-neutral-900 dark:text-neutral-100"
+  >
+    <header>
+      <h1
+        class="text-2xl font-semibold"
+      >
+        Task Statistics
+      </h1>
+    </header>
+    <section
+      class="space-y-2"
+    >
+      <p>
+        Total Tasks: 
+        2
+      </p>
+      <p>
+        Completion Rate: 
+        50
+        %
+      </p>
+    </section>
+    <section
+      class="space-y-2"
+    >
+      <h2
+        class="text-xl font-medium"
+      >
+        By Status
+      </h2>
+      <ul>
+        <li>
+          TODO
+          : 
+          1
+        </li>
+        <li>
+          DONE
+          : 
+          1
+        </li>
+      </ul>
+      <div
+        data="[object Object],[object Object]"
+        height="200"
+        width="400"
+      />
+    </section>
+    <section
+      class="space-y-2"
+    >
+      <h2
+        class="text-xl font-medium"
+      >
+        By Subject
+      </h2>
+      <ul>
+        <li>
+          Math
+          : 
+          1
+        </li>
+        <li>
+          Science
+          : 
+          1
+        </li>
+      </ul>
+      <div
+        height="200"
+        width="400"
+      />
+    </section>
+  </main>
+</div>
+`;

--- a/src/app/stats/page.test.tsx
+++ b/src/app/stats/page.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import React from 'react';
 import { render, screen, cleanup } from '@testing-library/react';
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import * as matchers from '@testing-library/jest-dom/matchers';
 
 vi.mock('@/server/api/react', () => ({
@@ -14,6 +14,11 @@ vi.mock('@/server/api/react', () => ({
   },
 }));
 
+let mockTheme = 'light';
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ resolvedTheme: mockTheme }),
+}));
+
 import { api } from '@/server/api/react';
 import StatsPage from './page';
 
@@ -24,6 +29,7 @@ expect.extend(matchers);
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  mockTheme = 'light';
 });
 
 describe('StatsPage', () => {
@@ -55,5 +61,31 @@ describe('StatsPage', () => {
 
     render(<StatsPage />);
     expect(screen.getByText('Error loading tasks')).toBeInTheDocument();
+  });
+
+  describe('visual regression', () => {
+    const tasks = [
+      { id: '1', status: 'TODO', subject: 'Math' },
+      { id: '2', status: 'DONE', subject: 'Science' },
+    ];
+
+    beforeEach(() => {
+      useQueryMock.mockReturnValue({
+        data: tasks,
+        isLoading: false,
+      });
+    });
+
+    it('matches light theme snapshot', () => {
+      mockTheme = 'light';
+      const { container } = render(<StatsPage />);
+      expect(container).toMatchSnapshot();
+    });
+
+    it('matches dark theme snapshot', () => {
+      mockTheme = 'dark';
+      const { container } = render(<StatsPage />);
+      expect(container).toMatchSnapshot();
+    });
   });
 });

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { useTheme } from "next-themes";
 import { api } from "@/server/api/react";
 import {
   BarChart,
@@ -15,6 +16,20 @@ import {
 
 export default function StatsPage() {
   const { data: tasks = [], isLoading, error } = api.task.list.useQuery();
+  const { resolvedTheme } = useTheme();
+
+  const isDark = resolvedTheme === "dark";
+  const chartColors = React.useMemo(
+    () => ({
+      text: isDark ? "#ffffff" : "#000000",
+      axis: isDark ? "#ffffff" : "#000000",
+      bar: isDark ? "#34d399" : "#8884d8",
+      pie: isDark
+        ? ["#34d399", "#60a5fa", "#fbbf24", "#fb923c"]
+        : ["#8884d8", "#82ca9d", "#ffc658", "#ff8042"],
+    }),
+    [isDark]
+  );
 
   if (error) return <main>Error loading tasks</main>;
   if (isLoading) return <main>Loading...</main>;
@@ -52,10 +67,8 @@ export default function StatsPage() {
       count: Number(count),
     }));
 
-  const COLORS = ["#8884d8", "#82ca9d", "#ffc658", "#ff8042"];
-
   return (
-    <main className="space-y-6">
+    <main className="space-y-6 text-neutral-900 dark:text-neutral-100">
       <header>
         <h1 className="text-2xl font-semibold">Task Statistics</h1>
       </header>
@@ -73,10 +86,18 @@ export default function StatsPage() {
           ))}
         </ul>
         <BarChart width={400} height={200} data={statusData}>
-          <XAxis dataKey="status" />
-          <YAxis allowDecimals={false} />
+          <XAxis
+            dataKey="status"
+            stroke={chartColors.axis}
+            tick={{ fill: chartColors.text }}
+          />
+          <YAxis
+            allowDecimals={false}
+            stroke={chartColors.axis}
+            tick={{ fill: chartColors.text }}
+          />
           <Tooltip />
-          <Bar dataKey="count" fill="#8884d8" />
+          <Bar dataKey="count" fill={chartColors.bar} />
         </BarChart>
       </section>
       <section className="space-y-2">
@@ -91,7 +112,10 @@ export default function StatsPage() {
         <PieChart width={400} height={200}>
           <Pie data={subjectData} dataKey="count" nameKey="subject" outerRadius={80}>
             {subjectData.map((_, index) => (
-              <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+              <Cell
+                key={`cell-${index}`}
+                fill={chartColors.pie[index % chartColors.pie.length]}
+              />
             ))}
           </Pie>
           <Tooltip />


### PR DESCRIPTION
## Summary
- detect light/dark theme in stats page and apply palette to charts
- snapshot tests for stats page covering light and dark themes
- document theme requirements for stats in AGENTS.md

## Testing
- `npm run lint`
- `CI=true npx vitest run src/app/stats/page.test.tsx`
- ⚠️ `CI=true npm test` (hung)


------
https://chatgpt.com/codex/tasks/task_e_68a6974c5d088320aa74ab3de719fed2