### PR TITLE
test: cover calendar interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,5 +44,15 @@ Notes:
 - No postinstall hook (avoids prisma generate before schema copy in Docker).
 - TypeScript 5.7.x + tRPC 11.4.4 + ESLint 8.57 aligned with Next 14.2.x.
 
+## Testing
+
+Run linting and the test suites locally:
+
+```bash
+npm run lint
+CI=true npm test
+npm run e2e
+```
+
 ## Problems
 - Drag reordering does not persist: Dragging tasks to a new order updates the UI briefly, but the order does not stay after refresh.

--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -1,9 +1,18 @@
 import { test, expect } from '@playwright/test';
 
-test('calendar view loads and shows tabs', async ({ page }) => {
-  await page.goto('/calendar');
-  await expect(page.getByRole('tab', { name: /week/i })).toBeVisible();
-  await page.getByRole('tab', { name: /day/i }).click();
-  await expect(page.getByRole('tab', { name: /day/i, selected: true })).toBeVisible();
-});
+test.describe('calendar views', () => {
+  test('switches between day, week, and month', async ({ page }) => {
+    await page.goto('/calendar');
 
+    await expect(page.getByRole('tab', { name: /week/i, selected: true })).toBeVisible();
+
+    await page.getByRole('tab', { name: /day/i }).click();
+    await expect(page.getByRole('tab', { name: /day/i, selected: true })).toBeVisible();
+
+    await page.getByRole('tab', { name: /month/i }).click();
+    await expect(page.getByRole('tab', { name: /month/i, selected: true })).toBeVisible();
+
+    const dayCells = await page.locator('[data-testid="day-cell"]').count();
+    expect(dayCells).toBeGreaterThan(20);
+  });
+});

--- a/src/components/calendar/CalendarGrid.test.tsx
+++ b/src/components/calendar/CalendarGrid.test.tsx
@@ -1,7 +1,40 @@
-import { cleanup, render, screen } from '@testing-library/react';
 import React from 'react';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+expect.extend(matchers);
+
+let dndDragEnd: ((e: any) => void) | undefined;
+const transforms = new Map<string, (t: any) => void>();
+const monitors: any[] = [];
+
+vi.mock('@dnd-kit/core', () => {
+  const React = require('react');
+  return {
+    DndContext: ({ children, onDragEnd }: any) => {
+      dndDragEnd = onDragEnd;
+      return <div>{children}</div>;
+    },
+    useDroppable: () => ({ setNodeRef: () => {}, isOver: false }),
+    useDraggable: ({ id }: any) => {
+      const [transform, setTransform] = React.useState<any>(null);
+      React.useEffect(() => {
+        transforms.set(id, setTransform);
+      }, [id]);
+      return { attributes: {}, listeners: {}, setNodeRef: () => {}, transform };
+    },
+    useDndMonitor: (cb: any) => {
+      monitors.push(cb);
+    },
+  };
+});
+
+afterAll(() => {
+  vi.unmock('@dnd-kit/core');
+});
+
 import { CalendarGrid } from './CalendarGrid';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DndContext } from '@dnd-kit/core';
 
 describe('CalendarGrid month view', () => {
   afterEach(() => {
@@ -22,41 +55,86 @@ describe('CalendarGrid month view', () => {
 
   it('renders events inside the correct month day cell', () => {
     vi.useFakeTimers();
-    // Fixed month for deterministic test
     vi.setSystemTime(new Date('2024-05-05T12:00:00Z'));
     const events = [
-      {
-        id: 'e1',
-        taskId: 't1',
-        title: 'Math HW',
-        startAt: '2024-05-10T09:00:00.000Z',
-        endAt: '2024-05-10T10:00:00.000Z',
-      },
-      {
-        id: 'e2',
-        taskId: 't2',
-        title: 'Science Project',
-        startAt: '2024-05-10T14:00:00.000Z',
-        endAt: '2024-05-10T15:00:00.000Z',
-      },
-      {
-        id: 'e3',
-        taskId: 't3',
-        title: 'Piano',
-        startAt: '2024-05-12T09:00:00.000Z',
-        endAt: '2024-05-12T10:00:00.000Z',
-      },
+      { id: 'e1', taskId: 't1', title: 'Math HW', startAt: '2024-05-10T09:00:00.000Z', endAt: '2024-05-10T10:00:00.000Z' },
+      { id: 'e2', taskId: 't2', title: 'Science Project', startAt: '2024-05-10T14:00:00.000Z', endAt: '2024-05-10T15:00:00.000Z' },
+      { id: 'e3', taskId: 't3', title: 'Piano', startAt: '2024-05-12T09:00:00.000Z', endAt: '2024-05-12T10:00:00.000Z' },
     ];
     render(<CalendarGrid view="month" events={events} onDropTask={() => {}} />);
-    // Should render each event title exactly once
     expect(screen.getByText('Math HW')).toBeInTheDocument();
     expect(screen.getByText('Science Project')).toBeInTheDocument();
     expect(screen.getByText('Piano')).toBeInTheDocument();
 
-    // Should place two events on the 10th cell and one on the 12th
     const may10Cell = screen.getByLabelText('month-day-2024-05-10');
     const may12Cell = screen.getByLabelText('month-day-2024-05-12');
     expect(may10Cell.querySelectorAll('[data-testid="month-event"]').length).toBe(2);
     expect(may12Cell.querySelectorAll('[data-testid="month-event"]').length).toBe(1);
+  });
+});
+
+describe('CalendarGrid interactions', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2099-01-01T00:00:00Z'));
+  });
+  afterEach(() => {
+    cleanup();
+    transforms.clear();
+    monitors.length = 0;
+    vi.useRealTimers();
+  });
+
+  it('calls onDropTask when a task is dropped onto a cell', () => {
+    const onDropTask = vi.fn();
+    render(
+      <DndContext
+        onDragEnd={(e: any) => {
+          const { active, over } = e;
+          if (!over) return;
+          const taskId = String(active.id).replace('task-', '');
+          const iso = String(over.id).replace('cell-', '');
+          onDropTask(taskId, new Date(iso));
+        }}
+      >
+        <CalendarGrid view="day" events={[]} onDropTask={onDropTask} />
+      </DndContext>
+    );
+    const iso = new Date('2099-01-01T08:00:00.000Z').toISOString();
+    dndDragEnd?.({ active: { id: 'task-42' }, over: { id: `cell-${iso}` } });
+    expect(onDropTask).toHaveBeenCalledWith('42', new Date(iso));
+  });
+
+  it('invokes onResizeEvent with updated time when resizing', () => {
+    const onResizeEvent = vi.fn();
+    const start = '2099-01-01T09:00:00.000Z';
+    const end = '2099-01-01T10:00:00.000Z';
+    render(
+      <CalendarGrid
+        view="day"
+        events={[{ id: 'e1', taskId: 't1', startAt: start, endAt: end, title: 'Study' }]}
+        onDropTask={() => {}}
+        onResizeEvent={onResizeEvent}
+      />
+    );
+    act(() => {
+      const setter = transforms.get('event-resize-end-e1');
+      setter?.({ x: 0, y: 48 });
+    });
+    monitors[0].onDragEnd({ active: { id: 'event-resize-end-e1' } });
+    expect(onResizeEvent).toHaveBeenCalledWith('e1', 'end', new Date('2099-01-01T11:00:00.000Z'));
+  });
+
+  it('stacks overlapping events in DOM order', () => {
+    const events = [
+      { id: 'a', taskId: 't1', startAt: '2099-01-01T09:00:00.000Z', endAt: '2099-01-01T10:00:00.000Z', title: 'Event A' },
+      { id: 'b', taskId: 't2', startAt: '2099-01-01T09:00:00.000Z', endAt: '2099-01-01T10:30:00.000Z', title: 'Event B' },
+    ];
+    render(<CalendarGrid view="day" events={events} onDropTask={() => {}} />);
+    const aBox = screen.getByText('Event A');
+    const bBox = screen.getByText('Event B');
+    expect(aBox).toBeInTheDocument();
+    expect(bBox).toBeInTheDocument();
+    expect(aBox.compareDocumentPosition(bBox) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- expand CalendarGrid tests for drag-and-drop, resizing and overlapping events
- add Playwright coverage for switching between day, week and month views
- document running lint, unit and e2e tests

## Testing
- `npm run lint`
- `npx vitest run src/components/calendar/CalendarGrid.test.tsx`
- `npm run e2e` *(fails: browserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68a697593d18832084a0c91a9548bc07