### PR TITLE
feat: add task recurrence support

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -93,6 +93,13 @@ enum TaskPriority {
   HIGH
 }
 
+enum RecurrenceType {
+  NONE
+  DAILY
+  WEEKLY
+  MONTHLY
+}
+
 model Task {
   id            String     @id @default(cuid())
   user          User?      @relation(fields: [userId], references: [id])
@@ -109,6 +116,8 @@ model Task {
   position      Int        @default(0)
   effortMinutes Int?
   dueAt         DateTime?
+  recurrenceType RecurrenceType @default(NONE)
+  recurrenceInterval Int @default(1)
   createdAt     DateTime   @default(now())
   updatedAt     DateTime   @updatedAt
 

--- a/src/components/task-modal.tsx
+++ b/src/components/task-modal.tsx
@@ -33,6 +33,8 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
   const [due, setDue] = useState<string>(""); // datetime-local
   const [dueEnabled, setDueEnabled] = useState<boolean>(false);
   const [priority, setPriority] = useState<"LOW" | "MEDIUM" | "HIGH">("MEDIUM");
+  const [recurrenceType, setRecurrenceType] = useState<'NONE' | 'DAILY' | 'WEEKLY' | 'MONTHLY'>('NONE');
+  const [recurrenceInterval, setRecurrenceInterval] = useState<number>(1);
 
   useEffect(() => {
     if (!open) return;
@@ -41,6 +43,8 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
       setSubject(task.subject ?? "");
       setNotes(task.notes ?? "");
       setPriority(task.priority ?? "MEDIUM");
+      setRecurrenceType(task.recurrenceType ?? 'NONE');
+      setRecurrenceInterval(task.recurrenceInterval ?? 1);
       const hasDue = task.dueAt != null;
       setDue(hasDue ? formatLocalDateTime(new Date(task.dueAt!)) : "");
       setDueEnabled(hasDue);
@@ -49,6 +53,8 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
       setSubject("");
       setNotes("");
       setPriority("MEDIUM");
+      setRecurrenceType('NONE');
+      setRecurrenceInterval(1);
       if (initialDueAt) {
         setDueEnabled(true);
         setDue(formatLocalDateTime(new Date(initialDueAt)));
@@ -116,13 +122,23 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
               notes: notes.trim() || null,
               dueAt,
               priority,
+              recurrenceType,
+              recurrenceInterval,
             });
           } else {
             if (!title.trim()) {
               toast.error("Title is required");
               return;
             }
-            create.mutate({ title: title.trim(), subject: subject || undefined, notes: notes || undefined, dueAt, priority });
+            create.mutate({
+              title: title.trim(),
+              subject: subject || undefined,
+              notes: notes || undefined,
+              dueAt,
+              priority,
+              recurrenceType,
+              recurrenceInterval,
+            });
           }
         }}
       >
@@ -209,6 +225,34 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
             <option value="HIGH">High</option>
           </select>
         </label>
+
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          <label className="flex flex-col gap-1">
+            <span className="text-xs uppercase tracking-wide opacity-60">Recurrence</span>
+            <select
+              className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+              value={recurrenceType}
+              onChange={(e) => setRecurrenceType(e.target.value as typeof recurrenceType)}
+            >
+              <option value="NONE">None</option>
+              <option value="DAILY">Daily</option>
+              <option value="WEEKLY">Weekly</option>
+              <option value="MONTHLY">Monthly</option>
+            </select>
+          </label>
+          {recurrenceType !== 'NONE' && (
+            <label className="flex flex-col gap-1">
+              <span className="text-xs uppercase tracking-wide opacity-60">Interval</span>
+              <input
+                type="number"
+                min={1}
+                className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+                value={recurrenceInterval}
+                onChange={(e) => setRecurrenceInterval(parseInt(e.target.value, 10) || 1)}
+              />
+            </label>
+          )}
+        </div>
 
         <label className="flex flex-col gap-1">
           <span className="text-xs uppercase tracking-wide opacity-60">Notes</span>

--- a/src/server/api/routers/task.test.ts
+++ b/src/server/api/routers/task.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { TaskPriority } from '@prisma/client';
+import { TaskPriority, RecurrenceType } from '@prisma/client';
 
 // Define hoisted fns for module mock
 const hoisted = vi.hoisted(() => {
@@ -90,6 +90,38 @@ describe('taskRouter.create', () => {
     await taskRouter.createCaller({}).create({ title: 'a', priority: TaskPriority.HIGH });
     expect(hoisted.create).toHaveBeenCalledWith({
       data: expect.objectContaining({ priority: TaskPriority.HIGH, title: 'a', dueAt: null, subject: null, notes: null }),
+    });
+  });
+
+  it('passes recurrence data to the database', async () => {
+    await taskRouter.createCaller({}).create({
+      title: 'a',
+      recurrenceType: RecurrenceType.DAILY,
+      recurrenceInterval: 2,
+    });
+    expect(hoisted.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        recurrenceType: RecurrenceType.DAILY,
+        recurrenceInterval: 2,
+      }),
+    });
+  });
+});
+
+describe('taskRouter.update recurrence', () => {
+  beforeEach(() => {
+    hoisted.update.mockClear();
+  });
+
+  it('updates recurrence fields', async () => {
+    await taskRouter.createCaller({}).update({
+      id: '1',
+      recurrenceType: RecurrenceType.WEEKLY,
+      recurrenceInterval: 3,
+    });
+    expect(hoisted.update).toHaveBeenCalledWith({
+      where: { id: '1' },
+      data: { recurrenceType: RecurrenceType.WEEKLY, recurrenceInterval: 3 },
     });
   });
 });

--- a/src/server/api/routers/task.ts
+++ b/src/server/api/routers/task.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { TRPCError } from '@trpc/server';
-import { TaskStatus, TaskPriority, Prisma } from '@prisma/client';
+import { TaskStatus, TaskPriority, Prisma, RecurrenceType } from '@prisma/client';
 import { publicProcedure, router } from '../trpc';
 import { db } from '@/server/db';
 export const taskRouter = router({
@@ -89,6 +89,8 @@ export const taskRouter = router({
         subject: z.string().max(100).optional(),
         notes: z.string().max(2000).optional(),
         priority: z.nativeEnum(TaskPriority).optional(),
+        recurrenceType: z.nativeEnum(RecurrenceType).optional(),
+        recurrenceInterval: z.number().int().min(1).optional(),
       })
     )
     .mutation(async ({ input }) => {
@@ -102,6 +104,8 @@ export const taskRouter = router({
           subject: input.subject ?? null,
           notes: input.notes ?? null,
           priority: input.priority ?? undefined,
+          recurrenceType: input.recurrenceType ?? undefined,
+          recurrenceInterval: input.recurrenceInterval ?? undefined,
         },
       });
     }),
@@ -114,6 +118,8 @@ export const taskRouter = router({
         notes: z.string().max(2000).nullable().optional(),
         dueAt: z.date().nullable().optional(),
         priority: z.nativeEnum(TaskPriority).optional(),
+        recurrenceType: z.nativeEnum(RecurrenceType).optional(),
+        recurrenceInterval: z.number().int().min(1).optional(),
       })
     )
     .mutation(async ({ input }) => {

--- a/src/server/jobs/recurrence.ts
+++ b/src/server/jobs/recurrence.ts
@@ -1,0 +1,48 @@
+import { addDays, addWeeks, addMonths } from 'date-fns';
+import { db } from '@/server/db';
+import { RecurrenceType } from '@prisma/client';
+
+export async function generateRecurringTasks(now = new Date()) {
+  const templates = await db.task.findMany({
+    where: {
+      recurrenceType: { not: RecurrenceType.NONE },
+      dueAt: { not: null },
+    },
+  });
+
+  for (const task of templates) {
+    if (!task.dueAt) continue;
+    let nextDue = task.dueAt;
+    while (nextDue <= now) {
+      nextDue =
+        task.recurrenceType === RecurrenceType.DAILY
+          ? addDays(nextDue, task.recurrenceInterval)
+          : task.recurrenceType === RecurrenceType.WEEKLY
+          ? addWeeks(nextDue, task.recurrenceInterval)
+          : addMonths(nextDue, task.recurrenceInterval);
+    }
+    const existing = await db.task.findFirst({
+      where: { title: task.title, dueAt: nextDue },
+    });
+    if (!existing) {
+      await db.task.create({
+        data: {
+          title: task.title,
+          subject: task.subject,
+          notes: task.notes,
+          priority: task.priority,
+          dueAt: nextDue,
+          userId: task.userId ?? undefined,
+          projectId: task.projectId ?? undefined,
+          courseId: task.courseId ?? undefined,
+          recurrenceType: task.recurrenceType,
+          recurrenceInterval: task.recurrenceInterval,
+        },
+      });
+    }
+  }
+}
+
+if (require.main === module) {
+  generateRecurringTasks().finally(() => process.exit(0));
+}


### PR DESCRIPTION
## Summary
- add recurrence fields to Task schema
- capture recurrence data in API and modal UI
- add recurring task generation job and tests

## Testing
- `npx prisma generate`
- `npx prisma db push` *(fails: Environment variable not found: DATABASE_URL)*
- `npm run lint`
- `CI=true npm test` *(no tests found/output)*

------
https://chatgpt.com/codex/tasks/task_e_68a69741c32083208b04c5ba1d020874