### PR TITLE
feat: improve modal accessibility

### DIFF
--- a/src/components/task-modal.test.tsx
+++ b/src/components/task-modal.test.tsx
@@ -63,3 +63,29 @@ describe('TaskModal due date editing', () => {
   });
 });
 
+describe('TaskModal accessibility', () => {
+  it('traps focus within the modal and focuses the first element initially', () => {
+    const onClose = vi.fn();
+    render(<TaskModal open mode="create" onClose={onClose} />);
+
+    const titleInput = screen.getByPlaceholderText('Task title');
+    expect(document.activeElement).toBe(titleInput);
+
+    const createButton = screen.getByText('Create');
+    createButton.focus();
+    fireEvent.keyDown(createButton, { key: 'Tab' });
+    expect(document.activeElement).toBe(titleInput);
+
+    fireEvent.keyDown(titleInput, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(createButton);
+  });
+
+  it('invokes onClose when Escape is pressed', () => {
+    const onClose = vi.fn();
+    render(<TaskModal open mode="create" onClose={onClose} />);
+
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+});
+

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React from "react";
+import React, { useEffect, useRef, useId } from "react";
 
 interface ModalProps {
   open: boolean;
@@ -9,13 +9,70 @@ interface ModalProps {
   footer?: React.ReactNode;
 }
 
+const focusableSelectors =
+  'a[href],button:not([disabled]),input:not([disabled]),textarea:not([disabled]),select:not([disabled]),[tabindex]:not([tabindex="-1"])';
+
 export function Modal({ open, onClose, title, children, footer }: ModalProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const titleId = useId();
+  const bodyId = useId();
+
+  useEffect(() => {
+    if (!open) return;
+    const node = dialogRef.current;
+    if (!node) return;
+
+    const getFocusable = () =>
+      Array.from(node.querySelectorAll<HTMLElement>(focusableSelectors));
+
+    const initial = getFocusable()[0];
+    (initial ?? node).focus();
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab") return;
+
+      const focusables = getFocusable();
+      if (focusables.length === 0) {
+        e.preventDefault();
+        return;
+      }
+
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement as HTMLElement;
+
+      if (e.shiftKey) {
+        if (active === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (active === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    node.addEventListener("keydown", handleKeyDown);
+    return () => node.removeEventListener("keydown", handleKeyDown);
+  }, [open, onClose]);
+
   if (!open) return null;
   return (
     <div
+      ref={dialogRef}
       className="fixed inset-0 z-50 flex items-center justify-center"
       aria-modal="true"
       role="dialog"
+      aria-labelledby={title ? titleId : undefined}
+      aria-describedby={bodyId}
+      tabIndex={-1}
     >
       <div
         className="absolute inset-0 bg-black/40 backdrop-blur-sm"
@@ -23,11 +80,16 @@ export function Modal({ open, onClose, title, children, footer }: ModalProps) {
       />
       <div className="relative z-10 w-full max-w-lg rounded-xl border border-black/10 bg-white/90 p-4 shadow-2xl dark:border-white/10 dark:bg-neutral-900/90">
         {title && (
-          <div className="mb-3 border-b border-black/10 pb-2 text-lg font-semibold dark:border-white/10">
+          <div
+            id={titleId}
+            className="mb-3 border-b border-black/10 pb-2 text-lg font-semibold dark:border-white/10"
+          >
             {title}
           </div>
         )}
-        <div className="space-y-3">{children}</div>
+        <div id={bodyId} className="space-y-3">
+          {children}
+        </div>
         {footer && <div className="mt-4 flex justify-end gap-2">{footer}</div>}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- trap focus and handle Escape in modal component
- add aria labels and initial focus for modal content
- test modal focus trap and ESC close behavior

## Testing
- `npm run lint`
- `CI=true npx vitest run src/components/task-modal.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a697490664832082cf9e9d1d441708