### PR TITLE
feat: make stats charts responsive

### DIFF
--- a/src/app/stats/__snapshots__/page.test.tsx.snap
+++ b/src/app/stats/__snapshots__/page.test.tsx.snap
@@ -46,10 +46,13 @@ exports[`StatsPage > visual regression > matches dark theme snapshot 1`] = `
         </li>
       </ul>
       <div
-        data="[object Object],[object Object]"
-        height="200"
-        width="400"
-      />
+        aspect="2"
+        width="100%"
+      >
+        <div
+          data="[object Object],[object Object]"
+        />
+      </div>
     </section>
     <section
       class="space-y-2"
@@ -72,9 +75,11 @@ exports[`StatsPage > visual regression > matches dark theme snapshot 1`] = `
         </li>
       </ul>
       <div
-        height="200"
-        width="400"
-      />
+        aspect="2"
+        width="100%"
+      >
+        <div />
+      </div>
     </section>
   </main>
 </div>
@@ -126,10 +131,13 @@ exports[`StatsPage > visual regression > matches light theme snapshot 1`] = `
         </li>
       </ul>
       <div
-        data="[object Object],[object Object]"
-        height="200"
-        width="400"
-      />
+        aspect="2"
+        width="100%"
+      >
+        <div
+          data="[object Object],[object Object]"
+        />
+      </div>
     </section>
     <section
       class="space-y-2"
@@ -152,9 +160,11 @@ exports[`StatsPage > visual regression > matches light theme snapshot 1`] = `
         </li>
       </ul>
       <div
-        height="200"
-        width="400"
-      />
+        aspect="2"
+        width="100%"
+      >
+        <div />
+      </div>
     </section>
   </main>
 </div>

--- a/src/app/stats/page.test.tsx
+++ b/src/app/stats/page.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import React from 'react';
 import { render, screen, cleanup } from '@testing-library/react';
-import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { describe, it, expect, vi, afterEach, beforeEach, beforeAll } from 'vitest';
 import * as matchers from '@testing-library/jest-dom/matchers';
 
 vi.mock('@/server/api/react', () => ({
@@ -25,6 +25,28 @@ import StatsPage from './page';
 const useQueryMock = api.task.list.useQuery as ReturnType<typeof vi.fn>;
 
 expect.extend(matchers);
+
+beforeAll(() => {
+  class ResizeObserver {
+    callback: ResizeObserverCallback;
+    constructor(callback: ResizeObserverCallback) {
+      this.callback = callback;
+    }
+    observe() {
+      this.callback(
+        [
+          {
+            contentRect: { width: 800, height: 400 },
+          } as unknown as ResizeObserverEntry,
+        ],
+        this
+      );
+    }
+    unobserve() {}
+    disconnect() {}
+  }
+  (global as any).ResizeObserver = ResizeObserver;
+});
 
 afterEach(() => {
   cleanup();

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -12,6 +12,7 @@ import {
   PieChart,
   Pie,
   Cell,
+  ResponsiveContainer,
 } from "recharts";
 
 export default function StatsPage() {
@@ -85,20 +86,22 @@ export default function StatsPage() {
             </li>
           ))}
         </ul>
-        <BarChart width={400} height={200} data={statusData}>
-          <XAxis
-            dataKey="status"
-            stroke={chartColors.axis}
-            tick={{ fill: chartColors.text }}
-          />
-          <YAxis
-            allowDecimals={false}
-            stroke={chartColors.axis}
-            tick={{ fill: chartColors.text }}
-          />
-          <Tooltip />
-          <Bar dataKey="count" fill={chartColors.bar} />
-        </BarChart>
+        <ResponsiveContainer width="100%" aspect={2}>
+          <BarChart data={statusData}>
+            <XAxis
+              dataKey="status"
+              stroke={chartColors.axis}
+              tick={{ fill: chartColors.text }}
+            />
+            <YAxis
+              allowDecimals={false}
+              stroke={chartColors.axis}
+              tick={{ fill: chartColors.text }}
+            />
+            <Tooltip />
+            <Bar dataKey="count" fill={chartColors.bar} />
+          </BarChart>
+        </ResponsiveContainer>
       </section>
       <section className="space-y-2">
         <h2 className="text-xl font-medium">By Subject</h2>
@@ -109,17 +112,19 @@ export default function StatsPage() {
             </li>
           ))}
         </ul>
-        <PieChart width={400} height={200}>
-          <Pie data={subjectData} dataKey="count" nameKey="subject" outerRadius={80}>
-            {subjectData.map((_, index) => (
-              <Cell
-                key={`cell-${index}`}
-                fill={chartColors.pie[index % chartColors.pie.length]}
-              />
-            ))}
-          </Pie>
-          <Tooltip />
-        </PieChart>
+        <ResponsiveContainer width="100%" aspect={2}>
+          <PieChart>
+            <Pie data={subjectData} dataKey="count" nameKey="subject" outerRadius={80}>
+              {subjectData.map((_, index) => (
+                <Cell
+                  key={`cell-${index}`}
+                  fill={chartColors.pie[index % chartColors.pie.length]}
+                />
+              ))}
+            </Pie>
+            <Tooltip />
+          </PieChart>
+        </ResponsiveContainer>
       </section>
     </main>
   );

--- a/src/test/recharts.mock.ts
+++ b/src/test/recharts.mock.ts
@@ -7,3 +7,4 @@ export const Tooltip = () => null;
 export const PieChart = (props: any) => React.createElement('div', props);
 export const Pie = () => null;
 export const Cell = () => null;
+export const ResponsiveContainer = (props: any) => React.createElement('div', props);

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -79,6 +79,7 @@ vi.mock('recharts', () => {
     PieChart: Div,
     Pie: Null,
     Cell: Null,
+    ResponsiveContainer: Div,
   } as any;
 });
 


### PR DESCRIPTION
## Summary
- make stats charts responsive by wrapping charts with ResponsiveContainer
- stub ResizeObserver and ResponsiveContainer in tests and update snapshots

## Testing
- `npm run lint`
- `CI=true npm test src/app/stats/page.test.tsx -u`


------
https://chatgpt.com/codex/tasks/task_e_68a6a05204f0832086f6cd61748a8916