### PR TITLE
feat: support priority filtering for tasks

### DIFF
--- a/src/components/task-filter-tabs.test.tsx
+++ b/src/components/task-filter-tabs.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import * as matchers from '@testing-library/jest-dom/matchers';
 import { TaskFilterTabs } from './task-filter-tabs';
+import { TaskPriority } from '@prisma/client';
 
 vi.mock('@/server/api/react', () => ({
   api: {
@@ -47,5 +48,20 @@ describe('TaskFilterTabs', () => {
     fireEvent.change(select, { target: { value: 'math' } });
     expect(handleSubject).toHaveBeenCalledWith('math');
     expect(screen.getByRole('option', { name: 'science' })).toBeInTheDocument();
+  });
+
+  it('renders priority options and calls onPriorityChange', () => {
+    const handlePriority = vi.fn();
+    render(
+      <TaskFilterTabs
+        value="all"
+        onChange={() => {}}
+        priority={null}
+        onPriorityChange={handlePriority}
+      />
+    );
+    const select = screen.getByLabelText('Priority filter');
+    fireEvent.change(select, { target: { value: TaskPriority.HIGH } });
+    expect(handlePriority).toHaveBeenCalledWith(TaskPriority.HIGH);
   });
 });

--- a/src/components/task-filter-tabs.tsx
+++ b/src/components/task-filter-tabs.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { api } from '@/server/api/react';
-import { Tag, ChevronDown } from 'lucide-react';
+import { Tag, ChevronDown, Flag } from 'lucide-react';
+import type { TaskPriority } from '@prisma/client';
 
 export type TaskFilter = 'all' | 'overdue' | 'today' | 'archive';
 
@@ -9,6 +10,8 @@ interface TaskFilterTabsProps {
   onChange: (value: TaskFilter) => void;
   subject?: string | null;
   onSubjectChange?: (value: string | null) => void;
+  priority?: TaskPriority | null;
+  onPriorityChange?: (value: TaskPriority | null) => void;
 }
 
 export function TaskFilterTabs({
@@ -16,6 +19,8 @@ export function TaskFilterTabs({
   onChange,
   subject,
   onSubjectChange,
+  priority,
+  onPriorityChange,
 }: TaskFilterTabsProps) {
   const options: { value: TaskFilter; label: string }[] = [
     { value: 'all', label: 'All' },
@@ -67,6 +72,24 @@ export function TaskFilterTabs({
                 {s}
               </option>
             ))}
+          </select>
+          <ChevronDown className="pointer-events-none absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+        </div>
+      )}
+      {onPriorityChange && (
+        <div className="relative ml-2">
+          <Flag className="pointer-events-none absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+          <select
+            aria-label="Priority filter"
+            title="Filter by priority"
+            className="appearance-none rounded-full border border-slate-200 bg-slate-100 py-1.5 pl-8 pr-8 text-sm text-slate-800 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-slate-400/50 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200 dark:hover:bg-slate-800"
+            value={priority ?? ''}
+            onChange={(e) => onPriorityChange(e.target.value ? (e.target.value as TaskPriority) : null)}
+          >
+            <option value="">All priorities</option>
+            <option value="HIGH">High</option>
+            <option value="MEDIUM">Medium</option>
+            <option value="LOW">Low</option>
           </select>
           <ChevronDown className="pointer-events-none absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
         </div>

--- a/src/components/task-list.test.tsx
+++ b/src/components/task-list.test.tsx
@@ -40,8 +40,8 @@ vi.mock('@dnd-kit/sortable', async () => {
 
 const defaultQuery = {
   data: [
-    { id: '1', title: 'Test 1', dueAt: null, status: 'DONE', subject: 'math' },
-    { id: '2', title: 'Test 2', dueAt: null, status: 'TODO', subject: 'science' },
+    { id: '1', title: 'Test 1', dueAt: null, status: 'DONE', subject: 'math', priority: 'HIGH' },
+    { id: '2', title: 'Test 2', dueAt: null, status: 'TODO', subject: 'science', priority: 'LOW' },
   ],
   isLoading: false,
   error: undefined,
@@ -213,6 +213,14 @@ describe('TaskList', () => {
     render(<TaskList />);
     const select = screen.getByLabelText('Subject filter');
     fireEvent.change(select, { target: { value: 'math' } });
+    expect(screen.getByText('Test 1')).toBeInTheDocument();
+    expect(screen.queryByText('Test 2')).not.toBeInTheDocument();
+  });
+
+  it('filters tasks by priority', () => {
+    render(<TaskList />);
+    const select = screen.getByLabelText('Priority filter');
+    fireEvent.change(select, { target: { value: 'HIGH' } });
     expect(screen.getByText('Test 1')).toBeInTheDocument();
     expect(screen.queryByText('Test 2')).not.toBeInTheDocument();
   });

--- a/src/components/task-list.tsx
+++ b/src/components/task-list.tsx
@@ -30,6 +30,7 @@ type Priority = "LOW" | "MEDIUM" | "HIGH";
 export function TaskList() {
   const [filter, setFilter] = useState<"all" | "overdue" | "today" | "archive">("all");
   const [subject, setSubject] = useState<string | null>(null);
+  const [priority, setPriority] = useState<Priority | null>(null);
   const [query, setQuery] = useState("");
   const utils = api.useUtils();
 
@@ -44,11 +45,12 @@ export function TaskList() {
     return {
       filter,
       subject: subject ?? undefined,
+      priority: priority ?? undefined,
       tzOffsetMinutes,
       todayStart: startLocal,
       todayEnd: endLocal,
     } as const;
-  }, [filter, subject]);
+  }, [filter, subject, priority]);
 
   const tasks = api.task.list.useQuery(queryInput);
   // Query archived count for header stats
@@ -164,9 +166,10 @@ export function TaskList() {
       orderedTasks.filter(
         (t) =>
           t.title.toLowerCase().includes(query.toLowerCase()) &&
-          (!subject || t.subject === subject)
+          (!subject || t.subject === subject) &&
+          (!priority || t.priority === priority)
       ),
-    [orderedTasks, query, subject]
+    [orderedTasks, query, subject, priority]
   );
   // Compute the visible ids in the current order; feed to SortableContext
   const visibleIds = React.useMemo(
@@ -321,6 +324,8 @@ export function TaskList() {
           onChange={setFilter}
           subject={subject}
           onSubjectChange={setSubject}
+          priority={priority}
+          onPriorityChange={setPriority}
         />
         <p className="text-xs text-gray-500 dark:text-gray-400">
           {archivedCount} archived

--- a/src/server/api/routers/task.test.ts
+++ b/src/server/api/routers/task.test.ts
@@ -65,6 +65,13 @@ describe('taskRouter.list ordering', () => {
     const arg = hoisted.findMany.mock.calls[0][0];
     expect(arg.where).toEqual({ subject: 'math' });
   });
+
+  it('filters by priority when provided', async () => {
+    await taskRouter.createCaller({}).list({ filter: 'all', priority: TaskPriority.HIGH });
+    expect(hoisted.findMany).toHaveBeenCalledTimes(1);
+    const arg = hoisted.findMany.mock.calls[0][0];
+    expect(arg.where).toEqual({ priority: TaskPriority.HIGH });
+  });
 });
 
 describe('taskRouter.reorder', () => {

--- a/src/server/api/routers/task.ts
+++ b/src/server/api/routers/task.ts
@@ -11,6 +11,7 @@ export const taskRouter = router({
         .object({
           filter: z.enum(['all', 'overdue', 'today', 'archive']).optional(),
           subject: z.string().optional(),
+          priority: z.nativeEnum(TaskPriority).optional(),
           // Minutes to add to UTC to get client local time offset (Date.getTimezoneOffset style)
           tzOffsetMinutes: z.number().int().optional(),
           // Optional explicit client-local day bounds as absolute instants
@@ -22,6 +23,7 @@ export const taskRouter = router({
     .query(async ({ input }) => {
       const filter = input?.filter ?? 'all';
       const subject = input?.subject;
+      const priority = input?.priority;
       const tzOffsetMinutes = input?.tzOffsetMinutes ?? null;
       const nowUtc = new Date();
 
@@ -62,6 +64,9 @@ export const taskRouter = router({
 
       if (subject) {
         where = { ...where, subject };
+      }
+      if (priority) {
+        where = { ...where, priority };
       }
 
       const dueAtOrder: Prisma.TaskOrderByWithRelationInput = {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -83,10 +83,11 @@ vi.mock('recharts', () => {
 });
 
 // Mock Prisma enums to avoid requiring generated client in unit tests
-vi.mock('@prisma/client', () => {
-  return {
-    TaskPriority: { LOW: 'LOW', MEDIUM: 'MEDIUM', HIGH: 'HIGH' },
-    TaskStatus: { TODO: 'TODO', IN_PROGRESS: 'IN_PROGRESS', DONE: 'DONE', CANCELLED: 'CANCELLED' },
-    Prisma: {},
-  } as any;
-});
+  vi.mock('@prisma/client', () => {
+    return {
+      TaskPriority: { LOW: 'LOW', MEDIUM: 'MEDIUM', HIGH: 'HIGH' },
+      TaskStatus: { TODO: 'TODO', IN_PROGRESS: 'IN_PROGRESS', DONE: 'DONE', CANCELLED: 'CANCELLED' },
+      RecurrenceType: { DAILY: 'DAILY', WEEKLY: 'WEEKLY', MONTHLY: 'MONTHLY' },
+      Prisma: {},
+    } as any;
+  });


### PR DESCRIPTION
## Summary
- allow passing `priority` to task list router and query
- add priority selector to task filter tabs and task list
- cover server-side and UI priority filtering in unit tests

## Testing
- `npm run lint`
- `npx vitest run src/server/api/routers/task.test.ts`
- `npx vitest run src/components/task-filter-tabs.test.tsx`
- `npx vitest run src/components/task-list.test.tsx -t "filters tasks by priority"`


------
https://chatgpt.com/codex/tasks/task_e_68a6a082730c8320a786e7fa2e337b26