### PR TITLE
feat: add project and course management

### DIFF
--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -1,0 +1,103 @@
+"use client";
+import React, { useState } from "react";
+import { api } from "@/server/api/react";
+import { Button } from "@/components/ui/button";
+
+export default function CoursesPage() {
+  const utils = api.useUtils();
+  const { data: courses = [] } = api.course.list.useQuery();
+  const create = api.course.create.useMutation({
+    onSuccess: () => utils.course.list.invalidate(),
+  });
+  const [title, setTitle] = useState("");
+  const [term, setTerm] = useState("");
+  const [color, setColor] = useState("");
+
+  return (
+    <main className="space-y-6">
+      <h1 className="text-2xl font-semibold">Courses</h1>
+      <div className="flex flex-col gap-2 max-w-md">
+        <input
+          className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+          placeholder="Course title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+        <input
+          className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+          placeholder="Term (optional)"
+          value={term}
+          onChange={(e) => setTerm(e.target.value)}
+        />
+        <input
+          className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+          placeholder="Color (optional)"
+          value={color}
+          onChange={(e) => setColor(e.target.value)}
+        />
+        <Button
+          onClick={() => {
+            const t = title.trim();
+            if (!t) return;
+            create.mutate({ title: t, term: term.trim() || undefined, color: color.trim() || undefined });
+            setTitle("");
+            setTerm("");
+            setColor("");
+          }}
+        >
+          Add Course
+        </Button>
+      </div>
+      <ul className="space-y-4 max-w-md">
+        {courses.map((c) => (
+          <CourseItem key={c.id} course={c} />
+        ))}
+      </ul>
+    </main>
+  );
+}
+
+function CourseItem({ course }: { course: { id: string; title: string; term: string | null; color: string | null } }) {
+  const utils = api.useUtils();
+  const update = api.course.update.useMutation({
+    onSuccess: () => utils.course.list.invalidate(),
+  });
+  const del = api.course.delete.useMutation({
+    onSuccess: () => utils.course.list.invalidate(),
+  });
+  const [title, setTitle] = useState(course.title);
+  const [term, setTerm] = useState(course.term ?? "");
+  const [color, setColor] = useState(course.color ?? "");
+  return (
+    <li className="flex flex-col gap-2 border-b pb-4">
+      <input
+        className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+      />
+      <input
+        className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+        value={term}
+        onChange={(e) => setTerm(e.target.value)}
+      />
+      <input
+        className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+        value={color}
+        onChange={(e) => setColor(e.target.value)}
+      />
+      <div className="flex gap-2">
+        <Button
+          onClick={() =>
+            update.mutate({ id: course.id, title: title.trim(), term: term.trim() || null, color: color.trim() || null })
+          }
+        >
+          Save
+        </Button>
+        <Button variant="danger" onClick={() => del.mutate({ id: course.id })}>
+          Delete
+        </Button>
+      </div>
+    </li>
+  );
+}
+

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,0 +1,89 @@
+"use client";
+import React, { useState } from "react";
+import { api } from "@/server/api/react";
+import { Button } from "@/components/ui/button";
+
+export default function ProjectsPage() {
+  const utils = api.useUtils();
+  const { data: projects = [] } = api.project.list.useQuery();
+  const create = api.project.create.useMutation({
+    onSuccess: () => utils.project.list.invalidate(),
+  });
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+
+  return (
+    <main className="space-y-6">
+      <h1 className="text-2xl font-semibold">Projects</h1>
+      <div className="flex flex-col gap-2 max-w-md">
+        <input
+          className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+          placeholder="Project title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+        <textarea
+          className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+          placeholder="Description (optional)"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+        <Button
+          onClick={() => {
+            const t = title.trim();
+            if (!t) return;
+            create.mutate({ title: t, description: description.trim() || undefined });
+            setTitle("");
+            setDescription("");
+          }}
+        >
+          Add Project
+        </Button>
+      </div>
+      <ul className="space-y-4 max-w-md">
+        {projects.map((p) => (
+          <ProjectItem key={p.id} project={p} />
+        ))}
+      </ul>
+    </main>
+  );
+}
+
+function ProjectItem({ project }: { project: { id: string; title: string; description: string | null } }) {
+  const utils = api.useUtils();
+  const update = api.project.update.useMutation({
+    onSuccess: () => utils.project.list.invalidate(),
+  });
+  const del = api.project.delete.useMutation({
+    onSuccess: () => utils.project.list.invalidate(),
+  });
+  const [title, setTitle] = useState(project.title);
+  const [description, setDescription] = useState(project.description ?? "");
+  return (
+    <li className="flex flex-col gap-2 border-b pb-4">
+      <input
+        className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+      />
+      <textarea
+        className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+      />
+      <div className="flex gap-2">
+        <Button
+          onClick={() =>
+            update.mutate({ id: project.id, title: title.trim(), description: description.trim() || null })
+          }
+        >
+          Save
+        </Button>
+        <Button variant="danger" onClick={() => del.mutate({ id: project.id })}>
+          Delete
+        </Button>
+      </div>
+    </li>
+  );
+}
+

--- a/src/app/tasks/page.test.tsx
+++ b/src/app/tasks/page.test.tsx
@@ -33,6 +33,8 @@ vi.mock('@/server/api/react', () => ({
       bulkUpdate: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },
       bulkDelete: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },
     },
+    project: { list: { useQuery: () => ({ data: [] }) } },
+    course: { list: { useQuery: () => ({ data: [] }) } },
   },
 }));
 

--- a/src/components/new-task-form.test.tsx
+++ b/src/components/new-task-form.test.tsx
@@ -32,6 +32,8 @@ vi.mock('@/server/api/react', () => ({
       updateTitle: { useMutation: () => ({ mutate: vi.fn() }) },
       setStatus: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: { message: 'Failed to update status' } }) },
     },
+    project: { list: { useQuery: () => ({ data: [] }) } },
+    course: { list: { useQuery: () => ({ data: [] }) } },
   },
 }));
 

--- a/src/components/task-list.test.tsx
+++ b/src/components/task-list.test.tsx
@@ -19,6 +19,7 @@ vi.mock('@dnd-kit/core', () => ({
     return <div>{children}</div>;
   },
   closestCenter: vi.fn(),
+  useDndMonitor: vi.fn(),
 }));
 vi.mock('@dnd-kit/sortable', async () => {
   return {
@@ -84,6 +85,8 @@ vi.mock('@/server/api/react', () => ({
       bulkUpdate: { useMutation: () => ({ mutate: bulkUpdateMock, isPending: false, error: undefined }) },
       bulkDelete: { useMutation: () => ({ mutate: bulkDeleteMock, isPending: false, error: undefined }) },
     },
+    project: { list: { useQuery: () => ({ data: [] }) } },
+    course: { list: { useQuery: () => ({ data: [] }) } },
   },
 }));
 

--- a/src/components/task-modal.test.tsx
+++ b/src/components/task-modal.test.tsx
@@ -22,6 +22,8 @@ vi.mock('@/server/api/react', () => ({
       delete: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
       setStatus: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
     },
+    project: { list: { useQuery: () => ({ data: [{ id: 'p1', title: 'Project 1' }] }) } },
+    course: { list: { useQuery: () => ({ data: [{ id: 'c1', title: 'Course 1' }] }) } },
   },
 }));
 
@@ -60,6 +62,22 @@ describe('TaskModal due date editing', () => {
     expect(d.getDate()).toBe(31);
     expect(d.getHours()).toBe(23);
     expect(d.getMinutes()).toBe(59);
+  });
+});
+
+describe('TaskModal project and course selection', () => {
+  beforeEach(() => {
+    mutateCreate.mockReset();
+  });
+  it('sends selected project and course when creating', () => {
+    render(<TaskModal open mode="create" onClose={() => {}} />);
+    fireEvent.change(screen.getByPlaceholderText('Task title'), { target: { value: 'T' } });
+    fireEvent.change(screen.getByLabelText('Project'), { target: { value: 'p1' } });
+    fireEvent.change(screen.getByLabelText('Course'), { target: { value: 'c1' } });
+    fireEvent.click(screen.getByText('Create'));
+    expect(mutateCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'T', projectId: 'p1', courseId: 'c1' })
+    );
   });
 });
 

--- a/src/components/task-modal.tsx
+++ b/src/components/task-modal.tsx
@@ -35,6 +35,10 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
   const [priority, setPriority] = useState<"LOW" | "MEDIUM" | "HIGH">("MEDIUM");
   const [recurrenceType, setRecurrenceType] = useState<'NONE' | 'DAILY' | 'WEEKLY' | 'MONTHLY'>('NONE');
   const [recurrenceInterval, setRecurrenceInterval] = useState<number>(1);
+  const { data: projects = [] } = api.project.list.useQuery();
+  const { data: courses = [] } = api.course.list.useQuery();
+  const [projectId, setProjectId] = useState<string | null>(null);
+  const [courseId, setCourseId] = useState<string | null>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -45,6 +49,8 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
       setPriority(task.priority ?? "MEDIUM");
       setRecurrenceType(task.recurrenceType ?? 'NONE');
       setRecurrenceInterval(task.recurrenceInterval ?? 1);
+      setProjectId(task.projectId ?? null);
+      setCourseId(task.courseId ?? null);
       const hasDue = task.dueAt != null;
       setDue(hasDue ? formatLocalDateTime(new Date(task.dueAt!)) : "");
       setDueEnabled(hasDue);
@@ -55,6 +61,8 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
       setPriority("MEDIUM");
       setRecurrenceType('NONE');
       setRecurrenceInterval(1);
+      setProjectId(null);
+      setCourseId(null);
       if (initialDueAt) {
         setDueEnabled(true);
         setDue(formatLocalDateTime(new Date(initialDueAt)));
@@ -124,6 +132,8 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
               priority,
               recurrenceType,
               recurrenceInterval,
+              projectId,
+              courseId,
             });
           } else {
             if (!title.trim()) {
@@ -138,6 +148,8 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
               priority,
               recurrenceType,
               recurrenceInterval,
+              projectId: projectId || undefined,
+              courseId: courseId || undefined,
             });
           }
         }}
@@ -212,6 +224,38 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
               disabled={!dueEnabled}
             />
           </div>
+        </div>
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          <label className="flex flex-col gap-1">
+            <span className="text-xs uppercase tracking-wide opacity-60">Project</span>
+            <select
+              className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+              value={projectId ?? ""}
+              onChange={(e) => setProjectId(e.target.value || null)}
+            >
+              <option value="">None</option>
+              {projects.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.title}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-xs uppercase tracking-wide opacity-60">Course</span>
+            <select
+              className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+              value={courseId ?? ""}
+              onChange={(e) => setCourseId(e.target.value || null)}
+            >
+              <option value="">None</option>
+              {courses.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.title}
+                </option>
+              ))}
+            </select>
+          </label>
         </div>
         <label className="flex flex-col gap-1">
           <span className="text-xs uppercase tracking-wide opacity-60">Priority</span>

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -3,11 +3,15 @@ import { router } from './trpc';
 import { taskRouter } from './routers/task';
 import { eventRouter } from './routers/event';
 import { focusRouter } from './routers/focus';
+import { projectRouter } from './routers/project';
+import { courseRouter } from './routers/course';
 
 export const appRouter = router({
   task: taskRouter,
   event: eventRouter,
   focus: focusRouter,
+  project: projectRouter,
+  course: courseRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/src/server/api/routers/course.test.ts
+++ b/src/server/api/routers/course.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const hoisted = vi.hoisted(() => {
+  const create = vi.fn().mockResolvedValue({});
+  const update = vi.fn().mockResolvedValue({});
+  return { create, update };
+});
+
+vi.mock('@/server/db', () => ({
+  db: {
+    course: {
+      findMany: vi.fn().mockResolvedValue([]),
+      create: hoisted.create,
+      update: hoisted.update,
+      delete: vi.fn().mockResolvedValue({}),
+    },
+  },
+}));
+
+import { courseRouter } from './course';
+
+describe('courseRouter.create', () => {
+  beforeEach(() => {
+    hoisted.create.mockClear();
+  });
+  it('creates course with title and optional fields', async () => {
+    await courseRouter.createCaller({}).create({ title: 'c', term: 'fall', color: 'red' });
+    expect(hoisted.create).toHaveBeenCalledWith({ data: { title: 'c', term: 'fall', color: 'red' } });
+  });
+});
+
+describe('courseRouter.update', () => {
+  beforeEach(() => {
+    hoisted.update.mockClear();
+  });
+  it('updates course fields', async () => {
+    await courseRouter.createCaller({}).update({ id: '1', title: 'nc', term: null, color: null });
+    expect(hoisted.update).toHaveBeenCalledWith({ where: { id: '1' }, data: { title: 'nc', term: null, color: null } });
+  });
+});
+

--- a/src/server/api/routers/course.ts
+++ b/src/server/api/routers/course.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+import { publicProcedure, router } from '../trpc';
+import { db } from '@/server/db';
+
+export const courseRouter = router({
+  list: publicProcedure.query(async () => {
+    return db.course.findMany();
+  }),
+  create: publicProcedure
+    .input(
+      z.object({
+        title: z.string().min(1).max(200),
+        term: z.string().max(100).optional(),
+        color: z.string().max(50).optional(),
+      })
+    )
+    .mutation(async ({ input }) => {
+      return db.course.create({
+        data: {
+          title: input.title,
+          term: input.term ?? null,
+          color: input.color ?? null,
+        },
+      });
+    }),
+  update: publicProcedure
+    .input(
+      z.object({
+        id: z.string().min(1),
+        title: z.string().min(1).max(200).optional(),
+        term: z.string().max(100).nullable().optional(),
+        color: z.string().max(50).nullable().optional(),
+      })
+    )
+    .mutation(async ({ input }) => {
+      const { id, ...rest } = input;
+      const data: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(rest)) {
+        if (typeof value !== 'undefined') data[key] = value;
+      }
+      if (Object.keys(data).length === 0) {
+        return db.course.findUniqueOrThrow({ where: { id } });
+      }
+      return db.course.update({ where: { id }, data });
+    }),
+  delete: publicProcedure
+    .input(z.object({ id: z.string().min(1) }))
+    .mutation(async ({ input }) => {
+      return db.course.delete({ where: { id: input.id } });
+    }),
+});
+
+export default courseRouter;

--- a/src/server/api/routers/project.test.ts
+++ b/src/server/api/routers/project.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const hoisted = vi.hoisted(() => {
+  const create = vi.fn().mockResolvedValue({});
+  const update = vi.fn().mockResolvedValue({});
+  return { create, update };
+});
+
+vi.mock('@/server/db', () => ({
+  db: {
+    project: {
+      findMany: vi.fn().mockResolvedValue([]),
+      create: hoisted.create,
+      update: hoisted.update,
+      delete: vi.fn().mockResolvedValue({}),
+    },
+  },
+}));
+
+import { projectRouter } from './project';
+
+describe('projectRouter.create', () => {
+  beforeEach(() => {
+    hoisted.create.mockClear();
+  });
+  it('creates project with title and description', async () => {
+    await projectRouter.createCaller({}).create({ title: 'p', description: 'd' });
+    expect(hoisted.create).toHaveBeenCalledWith({ data: { title: 'p', description: 'd' } });
+  });
+});
+
+describe('projectRouter.update', () => {
+  beforeEach(() => {
+    hoisted.update.mockClear();
+  });
+  it('updates project fields', async () => {
+    await projectRouter.createCaller({}).update({ id: '1', title: 'np', description: null });
+    expect(hoisted.update).toHaveBeenCalledWith({ where: { id: '1' }, data: { title: 'np', description: null } });
+  });
+});
+

--- a/src/server/api/routers/task.test.ts
+++ b/src/server/api/routers/task.test.ts
@@ -127,6 +127,13 @@ describe('taskRouter.create', () => {
       }),
     });
   });
+
+  it('passes project and course ids to the database', async () => {
+    await taskRouter.createCaller({}).create({ title: 'a', projectId: 'p1', courseId: 'c1' });
+    expect(hoisted.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ projectId: 'p1', courseId: 'c1', title: 'a', dueAt: null, subject: null, notes: null }),
+    });
+  });
 });
 
 describe('taskRouter.update recurrence', () => {
@@ -143,6 +150,20 @@ describe('taskRouter.update recurrence', () => {
     expect(hoisted.update).toHaveBeenCalledWith({
       where: { id: '1' },
       data: { recurrenceType: RecurrenceType.WEEKLY, recurrenceInterval: 3 },
+    });
+  });
+});
+
+describe('taskRouter.update project/course', () => {
+  beforeEach(() => {
+    hoisted.update.mockClear();
+  });
+
+  it('updates project and course ids', async () => {
+    await taskRouter.createCaller({}).update({ id: '1', projectId: 'p1', courseId: null });
+    expect(hoisted.update).toHaveBeenCalledWith({
+      where: { id: '1' },
+      data: { projectId: 'p1', courseId: null },
     });
   });
 });

--- a/src/server/api/routers/task.ts
+++ b/src/server/api/routers/task.ts
@@ -91,6 +91,8 @@ export const taskRouter = router({
         priority: z.nativeEnum(TaskPriority).optional(),
         recurrenceType: z.nativeEnum(RecurrenceType).optional(),
         recurrenceInterval: z.number().int().min(1).optional(),
+        projectId: z.string().min(1).optional(),
+        courseId: z.string().min(1).optional(),
       })
     )
     .mutation(async ({ input }) => {
@@ -106,6 +108,8 @@ export const taskRouter = router({
           priority: input.priority ?? undefined,
           recurrenceType: input.recurrenceType ?? undefined,
           recurrenceInterval: input.recurrenceInterval ?? undefined,
+          projectId: input.projectId ?? undefined,
+          courseId: input.courseId ?? undefined,
         },
       });
     }),
@@ -120,6 +124,8 @@ export const taskRouter = router({
         priority: z.nativeEnum(TaskPriority).optional(),
         recurrenceType: z.nativeEnum(RecurrenceType).optional(),
         recurrenceInterval: z.number().int().min(1).optional(),
+        projectId: z.string().nullable().optional(),
+        courseId: z.string().nullable().optional(),
       })
     )
     .mutation(async ({ input }) => {


### PR DESCRIPTION
## Summary
- add project and course dropdowns to task modal
- expose project and course routers for CRUD operations
- create basic management pages for projects and courses

## Testing
- `npm run lint`
- `npx vitest run --maxWorkers=2 --reporter=dot` *(fails: useDndMonitor must be used within a children of <DndContext>)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a08d841c8320b66407be0faa747e