### PR TITLE
feat: support custom day window preferences

### DIFF
--- a/src/app/calendar/page.test.tsx
+++ b/src/app/calendar/page.test.tsx
@@ -49,6 +49,9 @@ describe('CalendarPage', () => {
     focusStop.mockReset();
     scheduleMutate.mockReset();
     moveMutate.mockReset();
+    window.localStorage.clear();
+    window.localStorage.setItem('dayWindowStartHour', '6');
+    window.localStorage.setItem('dayWindowEndHour', '20');
   });
 
   it('defaults to Week view and can switch views', () => {
@@ -107,6 +110,8 @@ describe('CalendarPage', () => {
     const arg = scheduleMutate.mock.calls[0][0] as any;
     expect(arg.taskId).toBe('t1');
     expect(arg.durationMinutes).toBe(30);
+    expect(arg.dayWindowStartHour).toBe(6);
+    expect(arg.dayWindowEndHour).toBe(20);
   });
 
   it('reschedules an existing event when moved to a new slot', () => {
@@ -119,6 +124,8 @@ describe('CalendarPage', () => {
     expect(arg.startAt).toBeInstanceOf(Date);
     expect(arg.endAt).toBeInstanceOf(Date);
     expect(arg.endAt.getTime()).toBeGreaterThan(arg.startAt.getTime());
+    expect(arg.dayWindowStartHour).toBe(6);
+    expect(arg.dayWindowEndHour).toBe(20);
   });
 
   it('resizes an existing event when resize handle is dropped to a later slot', () => {
@@ -132,5 +139,7 @@ describe('CalendarPage', () => {
     expect(arg.startAt).toBeInstanceOf(Date);
     expect(arg.endAt).toBeInstanceOf(Date);
     expect(arg.endAt.getTime()).toBeGreaterThan(arg.startAt.getTime());
+    expect(arg.dayWindowStartHour).toBe(6);
+    expect(arg.dayWindowEndHour).toBe(20);
   });
 });

--- a/src/app/settings/page.test.tsx
+++ b/src/app/settings/page.test.tsx
@@ -1,0 +1,24 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, beforeEach } from "vitest";
+import * as matchers from "@testing-library/jest-dom/matchers";
+expect.extend(matchers);
+
+import SettingsPage from "./page";
+
+describe("SettingsPage", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("loads stored day window hours", () => {
+    window.localStorage.setItem("dayWindowStartHour", "6");
+    window.localStorage.setItem("dayWindowEndHour", "20");
+    render(<SettingsPage />);
+    const start = screen.getByLabelText(/day start hour/i) as HTMLInputElement;
+    const end = screen.getByLabelText(/day end hour/i) as HTMLInputElement;
+    expect(start.value).toBe("6");
+    expect(end.value).toBe("20");
+  });
+});

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,65 @@
+"use client";
+import React from "react";
+import ThemeToggle from "@/components/theme-toggle";
+
+export default function SettingsPage() {
+  const [startHour, setStartHour] = React.useState(8);
+  const [endHour, setEndHour] = React.useState(18);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+    const storedStart = window.localStorage.getItem("dayWindowStartHour");
+    const storedEnd = window.localStorage.getItem("dayWindowEndHour");
+    if (storedStart) setStartHour(Number(storedStart));
+    if (storedEnd) setEndHour(Number(storedEnd));
+  }, []);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem("dayWindowStartHour", String(startHour));
+  }, [startHour]);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem("dayWindowEndHour", String(endHour));
+  }, [endHour]);
+
+  return (
+    <main className="space-y-6">
+      <header className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Settings</h1>
+        <ThemeToggle />
+      </header>
+      <div className="space-y-4">
+        <div className="flex items-center gap-2">
+          <label htmlFor="day-start" className="w-48">
+            Day start hour
+          </label>
+          <input
+            id="day-start"
+            type="number"
+            min={0}
+            max={23}
+            value={startHour}
+            onChange={(e) => setStartHour(Number(e.target.value))}
+            className="w-20 rounded border px-2 py-1"
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <label htmlFor="day-end" className="w-48">
+            Day end hour
+          </label>
+          <input
+            id="day-end"
+            type="number"
+            min={0}
+            max={23}
+            value={endHour}
+            onChange={(e) => setEndHour(Number(e.target.value))}
+            className="w-20 rounded border px-2 py-1"
+          />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/calendar/CalendarGrid.test.tsx
+++ b/src/components/calendar/CalendarGrid.test.tsx
@@ -9,8 +9,8 @@ let dndDragEnd: ((e: any) => void) | undefined;
 const transforms = new Map<string, (t: any) => void>();
 const monitors: any[] = [];
 
-vi.mock('@dnd-kit/core', () => {
-  const React = require('react');
+vi.mock('@dnd-kit/core', async () => {
+  const React = await import('react');
   return {
     DndContext: ({ children, onDragEnd }: any) => {
       dndDragEnd = onDragEnd;
@@ -131,7 +131,11 @@ describe('CalendarGrid interactions', () => {
       { id: 'a', taskId: 't1', startAt: '2099-01-01T09:00:00.000Z', endAt: '2099-01-01T10:00:00.000Z', title: 'Event A' },
       { id: 'b', taskId: 't2', startAt: '2099-01-01T09:00:00.000Z', endAt: '2099-01-01T10:30:00.000Z', title: 'Event B' },
     ];
-    render(<CalendarGrid view="day" events={events} onDropTask={() => {}} />);
+    render(
+      <DndContext>
+        <CalendarGrid view="day" events={events} onDropTask={() => {}} />
+      </DndContext>
+    );
     const aBox = screen.getByText('Event A');
     const bBox = screen.getByText('Event B');
     expect(aBox).toBeInTheDocument();

--- a/src/lib/scheduling.test.ts
+++ b/src/lib/scheduling.test.ts
@@ -37,6 +37,30 @@ describe('findNonOverlappingSlot', () => {
     expect(result?.endAt.toISOString()).toBe('2099-01-01T09:30:00.000Z');
   });
 
+  it('honors custom day window bounds', () => {
+    const events: any[] = [];
+    const ok = findNonOverlappingSlot({
+      desiredStart: d('2099-01-01T05:00:00Z'),
+      durationMinutes: 60,
+      dayWindowStartHour: 5,
+      dayWindowEndHour: 7,
+      existing: events,
+      stepMinutes: 15,
+    });
+    expect(ok?.startAt.toISOString()).toBe('2099-01-01T05:00:00.000Z');
+    expect(ok?.endAt.toISOString()).toBe('2099-01-01T06:00:00.000Z');
+
+    const fail = findNonOverlappingSlot({
+      desiredStart: d('2099-01-01T06:30:00Z'),
+      durationMinutes: 60,
+      dayWindowStartHour: 5,
+      dayWindowEndHour: 7,
+      existing: events,
+      stepMinutes: 15,
+    });
+    expect(fail).toBeNull();
+  });
+
   it('returns null when no slot available before day end', () => {
     const events = [
       { startAt: d('2099-01-01T08:00:00Z'), endAt: d('2099-01-01T18:00:00Z') },


### PR DESCRIPTION
## Summary
- allow custom day window hours in event scheduling and moving
- add settings page to manage day window hours
- propagate day window preferences through calendar interactions

## Testing
- `npm run lint`
- `CI=true npx vitest run --reporter=basic` *(fails: process did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a0b22db88320946cbe08f361c09b