### PR TITLE
feat: make calendar and tasks responsive

### DIFF
--- a/src/app/calendar/page.test.tsx
+++ b/src/app/calendar/page.test.tsx
@@ -86,6 +86,13 @@ describe('CalendarPage', () => {
     expect(screen.getByTestId('calendar-grid')).toHaveTextContent('Scheduled task');
   });
 
+  it('applies responsive grid layout classes', () => {
+    render(<CalendarPage />);
+    const main = screen.getByRole('main');
+    expect(main).toHaveClass('grid-cols-1');
+    expect(main).toHaveClass('md:grid-cols-4');
+  });
+
   it('focus mode toggles on with Space on a task', () => {
     render(<CalendarPage />);
     const backlogItem = screen.getByRole('button', { name: /focus Unscheduled task/i });

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -210,8 +210,8 @@ export default function CalendarPage() {
 
   return (
     <ErrorBoundary fallback={<main>Failed to load calendar</main>}>
-    <main className="grid grid-cols-1 md:grid-cols-4 gap-4">
-      <div className="md:col-span-4 flex items-center justify-end">
+    <main className="grid w-full grid-cols-1 gap-4 md:grid-cols-4">
+      <div className="flex items-center justify-end md:col-span-4">
         <a
           href="/"
           className="rounded border px-3 py-1 text-sm hover:bg-black/5 dark:hover:bg-white/5"
@@ -281,7 +281,7 @@ export default function CalendarPage() {
           }
         }}
       >
-      <div className="md:col-span-1 space-y-3">
+      <div className="w-full space-y-3 md:col-span-1">
         {ViewTabs}
         <h2 className="font-semibold">Backlog</h2>
         <ul className="space-y-2">
@@ -319,7 +319,7 @@ export default function CalendarPage() {
           >Simulate Move</button>
         )}
       </div>
-      <div className="md:col-span-3">
+      <div className="w-full md:col-span-3">
         <div data-testid="calendar-grid">
           <CalendarGrid
             view={view}

--- a/src/components/__snapshots__/task-list.test.tsx.snap
+++ b/src/components/__snapshots__/task-list.test.tsx.snap
@@ -1,0 +1,199 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`TaskList > applies responsive max height for long lists 1`] = `
+<div>
+  <div
+    class="w-full space-y-3 md:w-auto"
+  >
+    <input
+      class="w-full bg-transparent border-0 px-0 py-1 outline-none placeholder:text-muted-foreground"
+      placeholder="Search tasks..."
+      type="text"
+      value=""
+    />
+    <div
+      class="flex items-center justify-between"
+    >
+      <div
+        aria-label="Task filter"
+        class="flex gap-2 items-center"
+        role="tablist"
+      >
+        <button
+          aria-selected="true"
+          class="bg-transparent px-3 py-1 text-sm border-b-2 transition border-black dark:border-white"
+          role="tab"
+          type="button"
+        >
+          All
+        </button>
+        <button
+          aria-selected="false"
+          class="bg-transparent px-3 py-1 text-sm border-b-2 transition border-transparent"
+          role="tab"
+          type="button"
+        >
+          Overdue
+        </button>
+        <button
+          aria-selected="false"
+          class="bg-transparent px-3 py-1 text-sm border-b-2 transition border-transparent"
+          role="tab"
+          type="button"
+        >
+          Today
+        </button>
+        <button
+          aria-selected="false"
+          class="bg-transparent px-3 py-1 text-sm border-b-2 transition border-transparent"
+          role="tab"
+          type="button"
+        >
+          Archive
+        </button>
+        <div
+          class="relative ml-2"
+        >
+          <svg
+            class="lucide lucide-tag pointer-events-none absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.586 2.586A2 2 0 0 0 11.172 2H4a2 2 0 0 0-2 2v7.172a2 2 0 0 0 .586 1.414l8.704 8.704a2.426 2.426 0 0 0 3.42 0l6.58-6.58a2.426 2.426 0 0 0 0-3.42z"
+            />
+            <circle
+              cx="7.5"
+              cy="7.5"
+              fill="currentColor"
+              r=".5"
+            />
+          </svg>
+          <select
+            aria-label="Subject filter"
+            class="appearance-none rounded-full border border-slate-200 bg-slate-100 py-1.5 pl-8 pr-8 text-sm text-slate-800 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-slate-400/50 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200 dark:hover:bg-slate-800"
+            title="Filter by subject"
+          >
+            <option
+              value=""
+            >
+              All subjects
+            </option>
+          </select>
+          <svg
+            class="lucide lucide-chevron-down pointer-events-none absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="m6 9 6 6 6-6"
+            />
+          </svg>
+        </div>
+        <div
+          class="relative ml-2"
+        >
+          <svg
+            class="lucide lucide-flag pointer-events-none absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z"
+            />
+            <line
+              x1="4"
+              x2="4"
+              y1="22"
+              y2="15"
+            />
+          </svg>
+          <select
+            aria-label="Priority filter"
+            class="appearance-none rounded-full border border-slate-200 bg-slate-100 py-1.5 pl-8 pr-8 text-sm text-slate-800 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-slate-400/50 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200 dark:hover:bg-slate-800"
+            title="Filter by priority"
+          >
+            <option
+              value=""
+            >
+              All priorities
+            </option>
+            <option
+              value="HIGH"
+            >
+              High
+            </option>
+            <option
+              value="MEDIUM"
+            >
+              Medium
+            </option>
+            <option
+              value="LOW"
+            >
+              Low
+            </option>
+          </select>
+          <svg
+            class="lucide lucide-chevron-down pointer-events-none absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="m6 9 6 6 6-6"
+            />
+          </svg>
+        </div>
+      </div>
+      <p
+        class="text-xs text-gray-500 dark:text-gray-400"
+      >
+        0
+         archived
+      </p>
+    </div>
+    <div>
+      <div
+        data-testid="sortable-context"
+      >
+        <div
+          class="overflow-auto max-h-[50vh] md:max-h-[600px]"
+          data-testid="task-scroll"
+        >
+          <div
+            style="height: 0px; position: relative;"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/task-list.tsx
+++ b/src/components/task-list.tsx
@@ -353,7 +353,7 @@ export function TaskList() {
   };
 
   return (
-    <div className="space-y-3">
+    <div className="w-full space-y-3 md:w-auto">
       <input
         type="text"
         value={query}
@@ -379,7 +379,7 @@ export function TaskList() {
           {useVirtual ? (
             <div
               ref={parentRef}
-              className="overflow-auto max-h-[600px]"
+              className="overflow-auto max-h-[50vh] md:max-h-[600px]"
               data-testid="task-scroll"
             >
               <div


### PR DESCRIPTION
## Summary
- apply responsive widths to calendar layout
- make task list scroll region height responsive and full width on mobile
- test responsive grid and add mobile snapshot for task list

## Testing
- `npm run lint`
- `CI=true npx vitest run src/components/task-list.test.tsx -t 'applies responsive max height for long lists' -u`
- `CI=true npx vitest run src/app/calendar/page.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68a7a4b0ae7c83209a5c0c68a52b7135