### PR TITLE
feat: cache task list

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ CI=true npm test
 npm run e2e
 ```
 
+## Caching
+
+`taskRouter.list` caches query results for 60 seconds using an in-memory store backed by
+[`@upstash/redis`](https://github.com/upstash/redis).
+Any mutation that changes tasks (create, update, delete, reorder, etc.) clears the cache so
+subsequent `list` calls return fresh data. Configure Redis via `REDIS_URL` and `REDIS_TOKEN` or
+leave them unset to fall back to a local in-memory cache.
+
 ## Problems
 - Drag reordering does not persist: Dragging tasks to a new order updates the UI briefly, but the order does not stay after refresh.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@trpc/client": "11.4.4",
         "@trpc/react-query": "11.4.4",
         "@trpc/server": "11.4.4",
+        "@upstash/redis": "^1.35.3",
         "bcryptjs": "^2.4.3",
         "clsx": "^2.1.1",
         "date-fns": "^3.6.0",
@@ -2199,6 +2200,15 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.35.3",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.35.3.tgz",
+      "integrity": "sha512-hSjv66NOuahW3MisRGlSgoszU2uONAY2l5Qo3Sae8OT3/Tng9K+2/cBRuyPBX8egwEGcNNCF9+r0V6grNnhL+w==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
@@ -8385,6 +8395,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undefsafe": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@trpc/client": "11.4.4",
     "@trpc/react-query": "11.4.4",
     "@trpc/server": "11.4.4",
+    "@upstash/redis": "^1.35.3",
     "bcryptjs": "^2.4.3",
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",

--- a/src/server/api/routers/task.ts
+++ b/src/server/api/routers/task.ts
@@ -3,6 +3,15 @@ import { TRPCError } from '@trpc/server';
 import { TaskStatus, TaskPriority, Prisma, RecurrenceType } from '@prisma/client';
 import { publicProcedure, router } from '../trpc';
 import { db } from '@/server/db';
+import { cache } from '@/server/cache';
+import type { Task } from '@prisma/client';
+
+const TASK_LIST_CACHE_PREFIX = 'task:list:';
+
+const buildListCacheKey = (input: unknown) =>
+  `${TASK_LIST_CACHE_PREFIX}${JSON.stringify(input ?? {})}`;
+
+const invalidateTaskListCache = () => cache.clear();
 export const taskRouter = router({
   // No authentication: list all tasks
   list: publicProcedure
@@ -85,7 +94,12 @@ export const taskRouter = router({
       const dueAtOrder: Prisma.TaskOrderByWithRelationInput = {
         dueAt: { sort: 'asc', nulls: 'last' },
       };
-      return db.task.findMany({
+
+      const cacheKey = buildListCacheKey(input);
+      const cached = await cache.get<Task[]>(cacheKey);
+      if (cached) return cached;
+
+      const tasks = await db.task.findMany({
         where,
         orderBy: [
           // Highest priority first
@@ -101,6 +115,8 @@ export const taskRouter = router({
         skip: cursor ? 1 : undefined,
         cursor: cursor ? { id: cursor } : undefined,
       });
+      await cache.set(cacheKey, tasks, 60);
+      return tasks;
     }),
   create: publicProcedure
     .input(
@@ -122,7 +138,7 @@ export const taskRouter = router({
       if (input.dueAt && input.dueAt < new Date()) {
         throw new TRPCError({ code: 'BAD_REQUEST', message: 'Due date cannot be in the past' });
       }
-      return db.task.create({
+      const created = await db.task.create({
         data: {
           title: input.title,
           dueAt: input.dueAt ?? null,
@@ -137,6 +153,8 @@ export const taskRouter = router({
           courseId: input.courseId ?? undefined,
         },
       });
+      await invalidateTaskListCache();
+      return created;
     }),
   update: publicProcedure
     .input(
@@ -164,8 +182,14 @@ export const taskRouter = router({
       for (const [key, value] of Object.entries(rest)) {
         if (typeof value !== 'undefined') data[key] = value;
       }
-      if (Object.keys(data).length === 0) return db.task.findUniqueOrThrow({ where: { id } });
-      return db.task.update({ where: { id }, data: data as Prisma.TaskUpdateInput });
+      let result: Task;
+      if (Object.keys(data).length === 0) {
+        result = await db.task.findUniqueOrThrow({ where: { id } });
+      } else {
+        result = await db.task.update({ where: { id }, data: data as Prisma.TaskUpdateInput });
+      }
+      await invalidateTaskListCache();
+      return result;
     }),
   setDueDate: publicProcedure
     .input(
@@ -175,14 +199,18 @@ export const taskRouter = router({
       if (input.dueAt && input.dueAt < new Date()) {
         throw new TRPCError({ code: 'BAD_REQUEST', message: 'Due date cannot be in the past' });
       }
-      return db.task.update({ where: { id: input.id }, data: { dueAt: input.dueAt ?? null } });
+      const updated = await db.task.update({ where: { id: input.id }, data: { dueAt: input.dueAt ?? null } });
+      await invalidateTaskListCache();
+      return updated;
     }),
   updateTitle: publicProcedure
     .input(
       z.object({ id: z.string().min(1), title: z.string().min(1).max(200) })
     )
     .mutation(async ({ input }) => {
-      return db.task.update({ where: { id: input.id }, data: { title: input.title } });
+      const updated = await db.task.update({ where: { id: input.id }, data: { title: input.title } });
+      await invalidateTaskListCache();
+      return updated;
     }),
   setStatus: publicProcedure
     .input(
@@ -192,7 +220,9 @@ export const taskRouter = router({
       })
     )
     .mutation(async ({ input }) => {
-      return db.task.update({ where: { id: input.id }, data: { status: input.status } });
+      const updated = await db.task.update({ where: { id: input.id }, data: { status: input.status } });
+      await invalidateTaskListCache();
+      return updated;
     }),
   bulkUpdate: publicProcedure
     .input(
@@ -206,6 +236,7 @@ export const taskRouter = router({
         where: { id: { in: input.ids } },
         data: { status: input.status },
       });
+      await invalidateTaskListCache();
       return { success: true };
     }),
   delete: publicProcedure
@@ -217,6 +248,7 @@ export const taskRouter = router({
         db.event.deleteMany({ where: { taskId: input.id } }),
         db.task.delete({ where: { id: input.id } }),
       ]);
+      await invalidateTaskListCache();
       return deleted;
     }),
   bulkDelete: publicProcedure
@@ -227,6 +259,7 @@ export const taskRouter = router({
         db.event.deleteMany({ where: { taskId: { in: input.ids } } }),
         db.task.deleteMany({ where: { id: { in: input.ids } } }),
       ]);
+      await invalidateTaskListCache();
       return { success: true };
     }),
   reorder: publicProcedure
@@ -237,6 +270,7 @@ export const taskRouter = router({
           db.task.update({ where: { id }, data: { position: index } })
         )
       );
+      await invalidateTaskListCache();
       return { success: true };
     }),
 });

--- a/src/server/cache.ts
+++ b/src/server/cache.ts
@@ -1,0 +1,49 @@
+import { Redis } from '@upstash/redis';
+
+interface CacheStore {
+  get<T>(key: string): Promise<T | null>;
+  set<T>(key: string, value: T, ttlSeconds?: number): Promise<void>;
+  clear(): Promise<void>;
+}
+
+const url = process.env.UPSTASH_REDIS_REST_URL || process.env.REDIS_URL;
+const token = process.env.UPSTASH_REDIS_REST_TOKEN || process.env.REDIS_TOKEN;
+
+let store: CacheStore;
+
+if (url && token) {
+  const redis = new Redis({ url, token });
+  store = {
+    async get<T>(key: string) {
+      return (await redis.get<T>(key)) ?? null;
+    },
+    async set<T>(key: string, value: T, ttlSeconds?: number) {
+      await redis.set(key, value, ttlSeconds ? { ex: ttlSeconds } : undefined);
+    },
+    async clear() {
+      await redis.flushdb();
+    },
+  };
+} else {
+  const map = new Map<string, { value: unknown; expires: number | null }>();
+  store = {
+    async get<T>(key: string) {
+      const entry = map.get(key);
+      if (!entry) return null;
+      if (entry.expires && entry.expires < Date.now()) {
+        map.delete(key);
+        return null;
+      }
+      return entry.value as T;
+    },
+    async set<T>(key: string, value: T, ttlSeconds?: number) {
+      map.set(key, { value, expires: ttlSeconds ? Date.now() + ttlSeconds * 1000 : null });
+    },
+    async clear() {
+      map.clear();
+    },
+  };
+}
+
+export const cache: CacheStore = store;
+


### PR DESCRIPTION
## Summary
- cache task list queries in Redis (or in-memory fallback)
- invalidate cached task lists on create, update, delete and reorder
- document caching strategy and add dependency

## Testing
- `npm run lint`
- `npx vitest run src/server/api/routers/task.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a7a4c0dfdc83208840dcac3166471b