### PR TITLE
feat: add rate limiter middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "next": "14.2.5",
         "next-auth": "4.24.7",
         "next-themes": "^0.4.6",
+        "rate-limiter-flexible": "^3.0.6",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-hot-toast": "^2.5.2",
@@ -6905,6 +6906,12 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/rate-limiter-flexible": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-3.0.6.tgz",
+      "integrity": "sha512-tlvbee6lyse/XTWmsuBDS4MT8N65FyM151bPmQlFyfhv9+RIHs7d3rSTXoz0j35H910dM01mH0yTIeWYo8+aAw==",
+      "license": "ISC"
     },
     "node_modules/react": {
       "version": "18.3.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "next": "14.2.5",
     "next-auth": "4.24.7",
     "next-themes": "^0.4.6",
+    "rate-limiter-flexible": "^3.0.6",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-hot-toast": "^2.5.2",

--- a/src/server/api/trpc.test.ts
+++ b/src/server/api/trpc.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { router, publicProcedure } from './trpc';
+
+const testRouter = router({
+  ping: publicProcedure.query(() => 'pong'),
+});
+
+// The rate limiter in trpc.ts allows 10 requests per 10 seconds.
+
+describe('tRPC rate limiting', () => {
+  it('throws TOO_MANY_REQUESTS after exceeding quota', async () => {
+    const caller = testRouter.createCaller({ ip: '1.1.1.1' });
+    for (let i = 0; i < 10; i++) {
+      await caller.ping();
+    }
+    await expect(caller.ping()).rejects.toMatchObject({ code: 'TOO_MANY_REQUESTS' });
+  });
+});

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -1,6 +1,24 @@
-import { initTRPC } from '@trpc/server';
+import { initTRPC, TRPCError } from '@trpc/server';
+import { RateLimiterMemory } from 'rate-limiter-flexible';
 import superjson from 'superjson';
 
+const rateLimiter = new RateLimiterMemory({
+  points: 10,
+  duration: 10,
+});
+
 export const t = initTRPC.create({ transformer: superjson });
+
+const rateLimit = t.middleware(async ({ ctx, next }) => {
+  const ip = ctx.ip as string | undefined;
+  if (!ip) return next();
+  try {
+    await rateLimiter.consume(ip);
+    return next();
+  } catch {
+    throw new TRPCError({ code: 'TOO_MANY_REQUESTS' });
+  }
+});
+
 export const router = t.router;
-export const publicProcedure = t.procedure;
+export const publicProcedure = t.procedure.use(rateLimit);


### PR DESCRIPTION
## Summary
- limit tRPC public procedures via `rate-limiter-flexible`
- test rate limiting returns 429 after quota

## Testing
- `npm run lint`
- `CI=true npx vitest run src/server/api/trpc.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a7a4c65f408320b02c14e4d970d183