### PR TITLE
feat: add default duration setting

### DIFF
--- a/src/app/calendar/page.test.tsx
+++ b/src/app/calendar/page.test.tsx
@@ -109,6 +109,15 @@ describe('CalendarPage', () => {
     expect(arg.dayWindowEndHour).toBe(20);
   });
 
+  it('uses stored default duration when scheduling a task', () => {
+    window.localStorage.setItem('defaultDurationMinutes', '45');
+    render(<CalendarPage />);
+    const simulateDrop = screen.getByRole('button', { name: /simulate-drop-unscheduled/i });
+    fireEvent.click(simulateDrop);
+    const arg = scheduleMutate.mock.calls[0][0] as any;
+    expect(arg.durationMinutes).toBe(45);
+  });
+
   it('reschedules an existing event when moved to a new slot', () => {
     render(<CalendarPage />);
     const simulateMove = screen.getByRole('button', { name: /simulate-move-event/i });

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -18,12 +18,15 @@ export default function CalendarPage() {
 
   const [dayStart, setDayStart] = useState(8);
   const [dayEnd, setDayEnd] = useState(18);
+  const [defaultDuration, setDefaultDuration] = useState(30);
   useEffect(() => {
     if (typeof window === 'undefined') return;
     const s = window.localStorage.getItem('dayWindowStartHour');
     const e = window.localStorage.getItem('dayWindowEndHour');
+    const d = window.localStorage.getItem('defaultDurationMinutes');
     if (s) setDayStart(Number(s));
     if (e) setDayEnd(Number(e));
+    if (d) setDefaultDuration(Number(d));
   }, []);
 
   // Make dragging/resizing more reliable across mouse/touch
@@ -233,7 +236,7 @@ export default function CalendarPage() {
             const taskId = aid.slice('task-'.length);
             const iso = oid.slice('cell-'.length);
             const startAt = new Date(iso);
-            scheduleWithPrefs({ taskId, startAt, durationMinutes: 30 });
+            scheduleWithPrefs({ taskId, startAt, durationMinutes: defaultDuration });
             return;
           }
           if (aid.startsWith('event-') && oid.startsWith('cell-')) {
@@ -300,7 +303,7 @@ export default function CalendarPage() {
             className="hidden"
             onClick={() => {
               const now = new Date();
-              scheduleWithPrefs({ taskId: backlog[0].id, startAt: now, durationMinutes: 30 });
+              scheduleWithPrefs({ taskId: backlog[0].id, startAt: now, durationMinutes: defaultDuration });
             }}
           >Simulate</button>
         )}
@@ -325,7 +328,7 @@ export default function CalendarPage() {
             view={view}
             startOfWeek={baseMonday}
             onDropTask={(taskId, startAt) => {
-              scheduleWithPrefs({ taskId, startAt, durationMinutes: 30 });
+              scheduleWithPrefs({ taskId, startAt, durationMinutes: defaultDuration });
             }}
             onMoveEvent={(eventId, startAt) => {
               const ev = eventsData.find((e) => e.id === eventId);

--- a/src/app/settings/page.test.tsx
+++ b/src/app/settings/page.test.tsx
@@ -21,4 +21,11 @@ describe("SettingsPage", () => {
     expect(start.value).toBe("6");
     expect(end.value).toBe("20");
   });
+
+  it("loads stored default duration", () => {
+    window.localStorage.setItem("defaultDurationMinutes", "45");
+    render(<SettingsPage />);
+    const duration = screen.getByLabelText(/default duration/i) as HTMLInputElement;
+    expect(duration.value).toBe("45");
+  });
 });

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -8,12 +8,15 @@ export default function SettingsPage() {
   // Day window (localStorage)
   const [startHour, setStartHour] = React.useState(8);
   const [endHour, setEndHour] = React.useState(18);
+  const [defaultDuration, setDefaultDuration] = React.useState(30);
   React.useEffect(() => {
     if (typeof window === "undefined") return;
     const storedStart = window.localStorage.getItem("dayWindowStartHour");
     const storedEnd = window.localStorage.getItem("dayWindowEndHour");
+    const storedDuration = window.localStorage.getItem("defaultDurationMinutes");
     if (storedStart) setStartHour(Number(storedStart));
     if (storedEnd) setEndHour(Number(storedEnd));
+    if (storedDuration) setDefaultDuration(Number(storedDuration));
   }, []);
   React.useEffect(() => {
     if (typeof window === "undefined") return;
@@ -23,6 +26,10 @@ export default function SettingsPage() {
     if (typeof window === "undefined") return;
     window.localStorage.setItem("dayWindowEndHour", String(endHour));
   }, [endHour]);
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem("defaultDurationMinutes", String(defaultDuration));
+  }, [defaultDuration]);
 
   // User timezone (tRPC)
   const { data: user } = api.user.get.useQuery();
@@ -49,7 +56,7 @@ export default function SettingsPage() {
       </header>
 
       <section className="space-y-4">
-        <h2 className="text-lg font-medium">Day Window</h2>
+        <h2 className="text-lg font-medium">Scheduling Preferences</h2>
         <div className="flex items-center gap-2">
           <label htmlFor="day-start" className="w-48">
             Day start hour
@@ -75,6 +82,19 @@ export default function SettingsPage() {
             max={23}
             value={endHour}
             onChange={(e) => setEndHour(Number(e.target.value))}
+            className="w-20 rounded border px-2 py-1"
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <label htmlFor="default-duration" className="w-48">
+            Default duration (minutes)
+          </label>
+          <input
+            id="default-duration"
+            type="number"
+            min={1}
+            value={defaultDuration}
+            onChange={(e) => setDefaultDuration(Number(e.target.value))}
             className="w-20 rounded border px-2 py-1"
           />
         </div>


### PR DESCRIPTION
## Summary
- allow configuring default task duration in settings and persist in localStorage
- use stored default duration when scheduling tasks
- cover custom duration scheduling in tests

## Testing
- `npm run lint`
- `npm test` *(fails: TaskList and other suites)*
- `npx vitest src/app/settings/page.test.tsx src/app/calendar/page.test.tsx`
- `npm run e2e` *(fails: Playwright task flow and calendar specs)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a4d3eb148320bbe217c8bd364730