### PR TITLE
fix: prioritize manual task order

### DIFF
--- a/src/server/api/routers/task.test.ts
+++ b/src/server/api/routers/task.test.ts
@@ -47,13 +47,13 @@ describe('taskRouter.list ordering', () => {
     hoisted.findMany.mockClear();
   });
 
-  it('orders by priority, then position, dueAt, then createdAt', async () => {
+  it('orders by position, then priority, dueAt, then createdAt', async () => {
     await taskRouter.createCaller({}).list({ filter: 'all' });
     expect(hoisted.findMany).toHaveBeenCalledTimes(1);
     const arg = hoisted.findMany.mock.calls[0][0];
     expect(arg.orderBy).toEqual([
-      { priority: 'desc' },
       { position: 'asc' },
+      { priority: 'desc' },
       { dueAt: { sort: 'asc', nulls: 'last' } },
       { createdAt: 'desc' },
     ]);

--- a/src/server/api/routers/task.ts
+++ b/src/server/api/routers/task.ts
@@ -88,11 +88,11 @@ export const taskRouter = router({
       return db.task.findMany({
         where,
         orderBy: [
-          // Highest priority first
-          { priority: 'desc' },
-          // Respect manual ordering within same priority
+          // Respect manual ordering first
           { position: 'asc' },
-          // Then sort by due date (nulls last) for items with equal positions
+          // Then highest priority within the same position
+          { priority: 'desc' },
+          // Next sort by due date (nulls last)
           dueAtOrder,
           // Finally, newest first as a tiebreaker
           { createdAt: 'desc' },


### PR DESCRIPTION
## Summary
- sort tasks by manual `position` before priority
- update task list ordering tests

## Testing
- `npm run lint`
- `CI=true npm test src/server/api/routers/task.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a7a4fd56f08320ab2eec9319e41bc5