### PR TITLE
fix: correct string slice usage in highlightMatches

### DIFF
--- a/src/components/task-list.tsx
+++ b/src/components/task-list.tsx
@@ -294,7 +294,7 @@ export function TaskList() {
       res.push(<mark key={i}>{text.slice(start, end + 1)}</mark>);
       last = end + 1;
     });
-    if (last < text.length) res.push(text.slice[last]);
+    if (last < text.length) res.push(text.slice(last));
     return res;
   };
 


### PR DESCRIPTION
## Summary
- fix incorrect string slice call when rendering highlight matches

## Testing
- `npm run lint`
- `CI=true npm test` (fails: TaskModal tests fail to handle simulated errors, new-task-form tests fail to create task)


------
https://chatgpt.com/codex/tasks/task_e_68acad80cbe08320a14ffbe89b44eabb