### PR TITLE
fix: selectively clear cache keys

### DIFF
--- a/src/server/cache.test.ts
+++ b/src/server/cache.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { cache, CACHE_PREFIX } from '@/server/cache';
+
+// Since env vars are not set, cache uses in-memory Map implementation.
+describe('cache.clear', () => {
+  it('removes only keys with the app prefix', async () => {
+    const prefixedKey = `${CACHE_PREFIX}foo`;
+    const otherKey = 'other:bar';
+
+    await cache.set(prefixedKey, 1);
+    await cache.set(otherKey, 2);
+
+    await cache.clear();
+
+    expect(await cache.get(prefixedKey)).toBeNull();
+    expect(await cache.get(otherKey)).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- clear cache by deleting only keys with the app prefix
- mirror selective clearing in local Map store
- test cache clear behavior

## Testing
- `npm run lint`
- `CI=true npm test` *(fails: TaskModal tests, NewTaskForm tests)*

------
https://chatgpt.com/codex/tasks/task_e_68acb1034378832083fc8b03bd472bd8