### PR TITLE
fix: include spanning events in listRange

### DIFF
--- a/src/server/api/routers/event.test.ts
+++ b/src/server/api/routers/event.test.ts
@@ -35,6 +35,37 @@ vi.mock('googleapis', () => ({
 
 import { eventRouter } from './event';
 
+describe('eventRouter.listRange', () => {
+  beforeEach(() => {
+    hoisted.findMany.mockReset();
+  });
+
+  it('returns events spanning the range', async () => {
+    const events = [
+      {
+        id: 'e1',
+        startAt: new Date('2023-01-01T08:00:00.000Z'),
+        endAt: new Date('2023-01-01T12:00:00.000Z'),
+      },
+    ];
+    hoisted.findMany.mockResolvedValueOnce(events);
+
+    const start = new Date('2023-01-01T09:00:00.000Z');
+    const end = new Date('2023-01-01T11:00:00.000Z');
+    const res = await eventRouter.createCaller({}).listRange({ start, end });
+
+    expect(hoisted.findMany).toHaveBeenCalledWith({
+      where: {
+        AND: [
+          { startAt: { lt: end } },
+          { endAt: { gt: start } },
+        ],
+      },
+    });
+    expect(res).toEqual(events);
+  });
+});
+
 describe('eventRouter.schedule', () => {
   beforeEach(() => {
     hoisted.findMany.mockReset();

--- a/src/server/api/routers/event.ts
+++ b/src/server/api/routers/event.ts
@@ -12,9 +12,9 @@ export const eventRouter = router({
     .query(async ({ input }) => {
       const where: Prisma.EventWhereInput = {};
       if (input?.start && input?.end) {
-        where.OR = [
-          { startAt: { gte: input.start, lt: input.end } },
-          { endAt: { gt: input.start, lte: input.end } },
+        where.AND = [
+          { startAt: { lt: input.end } },
+          { endAt: { gt: input.start } },
         ];
       }
       return db.event.findMany({ where });


### PR DESCRIPTION
## Summary
- change event listRange filter to include events overlapping the range
- add unit test covering spanning events in listRange

## Testing
- `npm run lint`
- `CI=true npm test -- src/server/api/routers/event.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68acb119de248320805ed5b40ec55cec