### PR TITLE
feat: display multi-day events across month view

### DIFF
--- a/src/components/calendar/CalendarGrid.test.tsx
+++ b/src/components/calendar/CalendarGrid.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import React from 'react';
-import { act, cleanup, render, screen } from '@testing-library/react';
+import { act, cleanup, render, screen, within } from '@testing-library/react';
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as matchers from '@testing-library/jest-dom/matchers';
 expect.extend(matchers);
@@ -71,6 +71,25 @@ describe('CalendarGrid month view', () => {
     const may12Cell = screen.getByLabelText('month-day-2024-05-12');
     expect(may10Cell.querySelectorAll('[data-testid="month-event"]').length).toBe(2);
     expect(may12Cell.querySelectorAll('[data-testid="month-event"]').length).toBe(1);
+  });
+
+  it('renders multi-day events across days', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-05-05T12:00:00Z'));
+    const events = [
+      {
+        id: 'm1',
+        taskId: 't1',
+        title: 'Retreat',
+        startAt: '2024-05-10T09:00:00.000Z',
+        endAt: '2024-05-12T10:00:00.000Z',
+      },
+    ];
+    render(<CalendarGrid view="month" events={events} onDropTask={() => {}} />);
+    ['2024-05-10', '2024-05-11', '2024-05-12'].forEach((d) => {
+      const cell = screen.getByLabelText(`month-day-${d}`);
+      expect(within(cell).getByText('Retreat')).toBeInTheDocument();
+    });
   });
 });
 

--- a/src/components/calendar/CalendarGrid.tsx
+++ b/src/components/calendar/CalendarGrid.tsx
@@ -31,10 +31,18 @@ export function CalendarGrid(props: {
     const eventsByDay = new Map<string, { id: string; title?: string }[]>();
     for (const ev of props.events) {
       const s = new Date(ev.startAt as any);
-      const key = ymd(s);
-      const list = eventsByDay.get(key) ?? [];
-      list.push({ id: ev.id, title: ev.title });
-      eventsByDay.set(key, list);
+      const e = new Date(ev.endAt as any);
+      const cur = new Date(s);
+      cur.setHours(0, 0, 0, 0);
+      const end = new Date(e);
+      end.setHours(0, 0, 0, 0);
+      while (cur <= end) {
+        const key = ymd(cur);
+        const list = eventsByDay.get(key) ?? [];
+        list.push({ id: ev.id, title: ev.title });
+        eventsByDay.set(key, list);
+        cur.setDate(cur.getDate() + 1);
+      }
     }
     return (
       <div className="border rounded overflow-hidden">


### PR DESCRIPTION
## Summary
- expand month-view event grouping to include every day between start and end dates
- test multi-day events appear on each day of the month grid

## Testing
- `npm run lint`
- `CI=true npm test -- src/components/calendar/CalendarGrid.test.tsx -t "CalendarGrid month view"`


------
https://chatgpt.com/codex/tasks/task_e_68acb13813108320813efe4acac41183