### PR TITLE
feat: card-style task list rows

### DIFF
--- a/src/components/task-list-skeleton.tsx
+++ b/src/components/task-list-skeleton.tsx
@@ -1,31 +1,18 @@
 'use client';
 import React from 'react';
 
-export function TaskListSkeleton(){
+export function TaskListSkeleton() {
+  const widths = ['100%', '95%', '90%', '85%', '92%'];
   return (
-    <div className="flex justify-center p-2" aria-label="Loading tasks">
-      <svg
-        className="h-5 w-5 animate-spin text-gray-500"
-        xmlns="http://www.w3.org/2000/svg"
-        fill="none"
-        viewBox="0 0 24 24"
-        role="status"
-        aria-label="Loading"
-      >
-        <circle
-          className="opacity-25"
-          cx="12"
-          cy="12"
-          r="10"
-          stroke="currentColor"
-          strokeWidth="4"
+    <ul className="space-y-2 p-2" aria-label="Loading tasks">
+      {widths.slice(0, 4).map((w, i) => (
+        <li
+          // eslint-disable-next-line react/no-array-index-key
+          key={i}
+          className="h-10 rounded-md border bg-neutral-200 dark:bg-neutral-700 animate-pulse"
+          style={{ width: w }}
         />
-        <path
-          className="opacity-75"
-          fill="currentColor"
-          d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
-        />
-      </svg>
-    </div>
+      ))}
+    </ul>
   );
 }

--- a/src/components/task-list.test.tsx
+++ b/src/components/task-list.test.tsx
@@ -20,8 +20,6 @@ vi.mock('@/server/api/react', () => ({
       delete: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },
       setStatus: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },
       reorder: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },
-      bulkUpdate: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },
-      bulkDelete: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },
     },
     user: { get: { useQuery: () => ({ data: null, isLoading: false, error: undefined }) } },
   },
@@ -47,6 +45,6 @@ describe('TaskList', () => {
         query="Beta"
       />
     );
-    expect(screen.getByText('No tasks.')).toBeInTheDocument();
+    expect(screen.getByText('Create your first task')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- style task rows as cards with drag handle, status dropdown and kebab
- add friendly empty state with CTA and keyboard tip
- swap spinner for skeleton list while loading

## Testing
- `npm run lint`
- `CI=true npm test` *(fails: useDndMonitor must be used within a children of <DndContext>, ReferenceError: setSelected is not defined, and other errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad210a36e88320aff23f45e578ef66