### PR TITLE
feat: redesign task item layout and status chip

### DIFF
--- a/src/components/status-dropdown.test.tsx
+++ b/src/components/status-dropdown.test.tsx
@@ -1,0 +1,22 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+expect.extend(matchers);
+import { StatusDropdown } from './status-dropdown';
+
+describe('StatusDropdown', () => {
+  it('uses soft background colors for each status', () => {
+    const { rerender } = render(
+      <StatusDropdown value="TODO" onChange={() => {}} />
+    );
+    expect(screen.getByRole('button')).toHaveClass('bg-neutral-100');
+
+    rerender(<StatusDropdown value="IN_PROGRESS" onChange={() => {}} />);
+    expect(screen.getByRole('button')).toHaveClass('bg-amber-50');
+
+    rerender(<StatusDropdown value="DONE" onChange={() => {}} />);
+    expect(screen.getByRole('button')).toHaveClass('bg-emerald-50');
+  });
+});

--- a/src/components/status-dropdown.tsx
+++ b/src/components/status-dropdown.tsx
@@ -12,19 +12,21 @@ const STATUS_LABELS: Record<TaskStatus, string> = {
 };
 
 const STATUS_STYLES: Record<TaskStatus, string> = {
-  TODO: "bg-slate-100 text-slate-700 ring-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:ring-slate-700",
+  TODO:
+    "bg-neutral-100 text-neutral-700 ring-neutral-200 dark:bg-neutral-800 dark:text-neutral-200 dark:ring-neutral-700",
   IN_PROGRESS:
-    "bg-blue-100 text-blue-700 ring-blue-200 dark:bg-blue-900/30 dark:text-blue-200 dark:ring-blue-800",
-  DONE: "bg-emerald-100 text-emerald-700 ring-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-200 dark:ring-emerald-800",
+    "bg-amber-50 text-amber-700 ring-amber-200 dark:bg-amber-900/30 dark:text-amber-200 dark:ring-amber-800",
+  DONE:
+    "bg-emerald-50 text-emerald-700 ring-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-200 dark:ring-emerald-800",
   CANCELLED:
-    "bg-gray-100 text-gray-700 ring-gray-200 dark:bg-gray-900/30 dark:text-gray-200 dark:ring-gray-700",
+    "bg-neutral-100 text-neutral-500 ring-neutral-200 dark:bg-neutral-800 dark:text-neutral-400 dark:ring-neutral-700",
 };
 
 const DOT_STYLES: Record<TaskStatus, string> = {
-  TODO: "bg-slate-500",
-  IN_PROGRESS: "bg-blue-500",
+  TODO: "bg-neutral-400",
+  IN_PROGRESS: "bg-amber-500",
   DONE: "bg-emerald-500",
-  CANCELLED: "bg-gray-400",
+  CANCELLED: "bg-neutral-400",
 };
 
 export interface StatusDropdownProps {

--- a/src/components/task-list.test.tsx
+++ b/src/components/task-list.test.tsx
@@ -15,12 +15,15 @@ vi.mock('@/server/api/react', () => ({
       list: {
         useInfiniteQuery: (...args: any[]) => useInfiniteQueryMock(...args),
       },
+      create: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },
       update: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },
       setDueDate: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },
       delete: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },
       setStatus: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },
       reorder: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },
     },
+    project: { list: { useQuery: () => ({ data: [], isLoading: false, error: undefined }) } },
+    course: { list: { useQuery: () => ({ data: [], isLoading: false, error: undefined }) } },
     user: { get: { useQuery: () => ({ data: null, isLoading: false, error: undefined }) } },
   },
 }));
@@ -46,5 +49,86 @@ describe('TaskList', () => {
       />
     );
     expect(screen.getByText('Create your first task')).toBeInTheDocument();
+  });
+
+  it('shows red due date text for overdue tasks', () => {
+    const now = new Date('2023-01-02T12:00:00Z');
+    vi.setSystemTime(now);
+    useInfiniteQueryMock.mockReturnValue({
+      data: {
+        pages: [[{ id: '1', title: 'Alpha', dueAt: new Date('2023-01-01T12:00:00Z'), status: 'TODO' }]],
+      },
+      isLoading: false,
+      error: undefined,
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+    render(
+      <TaskList
+        filter="all"
+        subject={null}
+        priority={null}
+        courseId={null}
+        projectId={null}
+        query=""
+      />
+    );
+    expect(screen.getByTestId('due-date')).toHaveClass('text-red-600');
+    vi.useRealTimers();
+  });
+
+  it('shows amber due date text for tasks due today', () => {
+    const now = new Date('2023-01-02T12:00:00Z');
+    vi.setSystemTime(now);
+    useInfiniteQueryMock.mockReturnValue({
+      data: {
+        pages: [[{ id: '1', title: 'Alpha', dueAt: new Date('2023-01-02T15:00:00Z'), status: 'TODO' }]],
+      },
+      isLoading: false,
+      error: undefined,
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+    render(
+      <TaskList
+        filter="all"
+        subject={null}
+        priority={null}
+        courseId={null}
+        projectId={null}
+        query=""
+      />
+    );
+    expect(screen.getByTestId('due-date')).toHaveClass('text-amber-600');
+    vi.useRealTimers();
+  });
+
+  it('shows neutral due date text for future tasks', () => {
+    const now = new Date('2023-01-02T12:00:00Z');
+    vi.setSystemTime(now);
+    useInfiniteQueryMock.mockReturnValue({
+      data: {
+        pages: [[{ id: '1', title: 'Alpha', dueAt: new Date('2023-01-03T12:00:00Z'), status: 'TODO' }]],
+      },
+      isLoading: false,
+      error: undefined,
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+    render(
+      <TaskList
+        filter="all"
+        subject={null}
+        priority={null}
+        courseId={null}
+        projectId={null}
+        query=""
+      />
+    );
+    expect(screen.getByTestId('due-date')).toHaveClass('text-neutral-500');
+    vi.useRealTimers();
   });
 });

--- a/src/components/task-list.tsx
+++ b/src/components/task-list.tsx
@@ -15,15 +15,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import {
-  Calendar,
-  Tag,
-  GripVertical,
-  ArrowUp,
-  ArrowDown,
-  Minus,
-  MoreVertical,
-} from "lucide-react";
+import { Calendar, Tag, Clock, GripVertical, MoreVertical } from "lucide-react";
 
 import { api } from "@/server/api/react";
 import type { RouterOutputs } from "@/server/api/root";
@@ -297,19 +289,18 @@ export function TaskList({
     if (isDragging) {
       style.transform = `${style.transform ?? ""} translateY(-1px)`;
     }
-    const overdue = t.dueAt ? new Date(t.dueAt) < new Date() : false;
     const done = t.status === "DONE";
-    const priority: Priority = t.priority ?? "MEDIUM";
-    const priorityStyles: Record<Priority, string> = {
-      HIGH: "bg-red-100 text-red-800 ring-red-300 dark:bg-red-950 dark:text-red-200 dark:ring-red-700",
-      MEDIUM: "bg-blue-100 text-blue-800 ring-blue-300 dark:bg-blue-950 dark:text-blue-200 dark:ring-blue-700",
-      LOW: "bg-slate-100 text-slate-800 ring-slate-300 dark:bg-slate-950 dark:text-slate-200 dark:ring-slate-700",
-    };
-    const priorityIcons: Record<Priority, React.ReactNode> = {
-      HIGH: <ArrowUp className="h-3 w-3" aria-hidden="true" />,
-      MEDIUM: <Minus className="h-3 w-3" aria-hidden="true" />,
-      LOW: <ArrowDown className="h-3 w-3" aria-hidden="true" />,
-    };
+    const dueDate = t.dueAt ? new Date(t.dueAt) : null;
+    let dueClass = "text-neutral-500";
+    if (dueDate) {
+      const now = new Date();
+      const start = new Date(now);
+      start.setHours(0, 0, 0, 0);
+      const end = new Date(now);
+      end.setHours(23, 59, 59, 999);
+      if (dueDate < start) dueClass = "text-red-600";
+      else if (dueDate <= end) dueClass = "text-amber-600";
+    }
     const match = matchesById.get(t.id)?.find((m) => m.key === "title");
     const titleNode = match && match.indices
       ? highlightMatches(t.title, match.indices as any)
@@ -321,56 +312,43 @@ export function TaskList({
         style={style}
         key={t.id}
         className={`group flex items-center justify-between rounded-md border bg-white p-3 transition-colors hover:bg-neutral-50 ${
-          overdue
-            ? 'border-red-500 bg-red-50 text-red-800 dark:bg-red-950 dark:text-red-200'
-            : ''
-        } ${isDragging ? 'shadow-sm ring-1 ring-neutral-200 translate-y-[-1px]' : ''}`}
+          isDragging ? 'shadow-sm ring-1 ring-neutral-200 translate-y-[-1px]' : ''
+        }`}
         onClick={() => setEditingTask(t)}
       >
-        <div className="flex items-center gap-3 flex-1">
+        <div className="flex items-start gap-3 flex-1">
           <button
             type="button"
             aria-label="Drag to reorder"
-            className="cursor-grab opacity-50 text-neutral-400 transition-opacity group-hover:opacity-100 active:cursor-grabbing"
+            className="cursor-grab text-neutral-400 hover:text-neutral-700 active:cursor-grabbing"
             {...attributes}
             {...listeners}
             onClick={(e) => e.stopPropagation()}
           >
             <GripVertical className="h-4 w-4" />
           </button>
-          <div className="flex flex-col flex-1 gap-1">
-            <div className="flex items-center gap-2">
-              {t.course?.color && (
-                <span
-                  data-testid="course-color"
-                  className="h-2 w-2 rounded-full"
-                  style={{ backgroundColor: t.course.color }}
-                />
-              )}
-              <span className={`font-medium ${done ? 'line-through opacity-60' : ''}`}>{titleNode}</span>
-            </div>
-            <div className="flex flex-wrap items-center gap-2 text-xs text-neutral-500 dark:text-neutral-400">
-              <span
-                className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 ring-1 ${priorityStyles[priority]}`}
-              >
-                {priorityIcons[priority]}
-                {priority.charAt(0) + priority.slice(1).toLowerCase()}
-              </span>
-              {t.subject && (
-                <span className="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 ring-1 ring-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:ring-slate-700">
-                  <Tag className="h-3 w-3" /> {t.subject}
+          <div className="flex flex-col flex-1">
+            <span className={`font-medium ${done ? 'line-through opacity-60' : ''}`}>{titleNode}</span>
+            {t.course?.title && (
+              <span className="text-sm text-neutral-500">{t.course.title}</span>
+            )}
+            <div className="mt-1 flex flex-wrap items-center gap-4 text-xs text-neutral-500">
+              {t.dueAt && (
+                <span data-testid="due-date" className={`flex items-center gap-1 ${dueClass}`}>
+                  <Calendar className="h-4 w-4 text-neutral-400" />
+                  {dueDate!.toLocaleDateString()}
                 </span>
               )}
-              {t.dueAt && (
-                <span
-                  className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 ring-1 ${
-                    overdue
-                      ? 'bg-red-100 text-red-700 ring-red-200 dark:bg-red-900/30 dark:text-red-200 dark:ring-red-800'
-                      : 'bg-amber-100 text-amber-700 ring-amber-200 dark:bg-amber-900/30 dark:text-amber-200 dark:ring-amber-800'
-                  }`}
-                >
-                  <Calendar className="h-3 w-3" />
-                  {new Date(t.dueAt!).toLocaleString()}
+              {t.subject && (
+                <span className="flex items-center gap-1">
+                  <Tag className="h-4 w-4 text-neutral-400" />
+                  {t.subject}
+                </span>
+              )}
+              {t.effortMinutes && (
+                <span className="flex items-center gap-1">
+                  <Clock className="h-4 w-4 text-neutral-400" />
+                  {t.effortMinutes}m
                 </span>
               )}
             </div>
@@ -384,7 +362,7 @@ export function TaskList({
           <button
             type="button"
             aria-label="More actions"
-            className="p-1 text-neutral-400 hover:text-neutral-600"
+            className="p-1 text-neutral-400 hover:text-neutral-700"
             onClick={(e) => {
               e.stopPropagation();
               setEditingTask(t);


### PR DESCRIPTION
## Summary
- restructure task list item to show title, course and metadata lines
- add soft-colored status chip styles
- color-code due dates by urgency and add tests

## Testing
- `npm run lint`
- `CI=true npm test -- src/components/status-dropdown.test.tsx src/components/task-list.test.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad281ffe908320a0b83d88f1e08f23