### PR TITLE
feat: add tags component with overflow counter

### DIFF
--- a/src/components/tags.test.tsx
+++ b/src/components/tags.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+import { Tags } from './tags';
+
+expect.extend(matchers);
+
+describe('Tags component', () => {
+  it('renders all tags when under the limit', () => {
+    render(<Tags items={['math', 'science', 'english']} />);
+    expect(screen.queryByText('+')).not.toBeInTheDocument();
+    expect(screen.getByText('math')).toBeInTheDocument();
+    expect(screen.getByText('science')).toBeInTheDocument();
+    expect(screen.getByText('english')).toBeInTheDocument();
+  });
+
+  it('shows a +N counter when tags exceed the limit', () => {
+    render(
+      <Tags items={['a', 'b', 'c', 'd', 'e', 'f']} maxVisible={4} />
+    );
+    expect(screen.getByText('+2')).toBeInTheDocument();
+  });
+});

--- a/src/components/tags.tsx
+++ b/src/components/tags.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+interface TagsProps {
+  /** List of tag labels to display */
+  items: string[];
+  /** Maximum number of tags to show before collapsing into a "+N" counter. Defaults to 5. */
+  maxVisible?: number;
+}
+
+/**
+ * Displays a list of tags as small rounded pills. When the number of tags
+ * exceeds `maxVisible`, the remaining count is summarized as a "+N" pill.
+ */
+export function Tags({ items, maxVisible = 5 }: TagsProps) {
+  const visible = items.slice(0, maxVisible);
+  const hiddenCount = items.length - visible.length;
+
+  return (
+    <div className="flex flex-wrap gap-1 text-[11px]">
+      {visible.map((tag) => (
+        <span
+          key={tag}
+          className="px-2 py-0.5 rounded-full bg-neutral-100"
+        >
+          {tag}
+        </span>
+      ))}
+      {hiddenCount > 0 && (
+        <span className="px-2 py-0.5 rounded-full bg-neutral-100">+{hiddenCount}</span>
+      )}
+    </div>
+  );
+}
+
+export default Tags;


### PR DESCRIPTION
## Summary
- add `Tags` component for rendering tag pills with overflow counter
- add unit tests for `Tags`

## Testing
- `npm run lint`
- `CI=true npx vitest run --dir src/components tags.test.tsx`
- `npm run build` *(fails: process did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68ad28290208832088700f8fcd10549b