### PR TITLE
feat: add toast notifications

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -6,8 +6,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { httpBatchLink } from "@trpc/client";
 import superjson from "superjson";
 import { Toaster } from "react-hot-toast";
-import { api } from "@/server/api/react";
 import { SessionProvider } from "next-auth/react";
+import { api } from "@/server/api/react";
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = React.useState(() => new QueryClient());
@@ -29,7 +29,28 @@ export default function Providers({ children }: { children: React.ReactNode }) {
         <api.Provider client={trpcClient} queryClient={queryClient}>
           <QueryClientProvider client={queryClient}>
             {children}
-            <Toaster />
+            <Toaster
+              position="top-right"
+              toastOptions={{
+                duration: 3500,
+                style: {
+                  background: "#f3f4f6",
+                  color: "#374151",
+                },
+                success: {
+                  style: {
+                    background: "#dcfce7",
+                    color: "#166534",
+                  },
+                },
+                error: {
+                  style: {
+                    background: "#fee2e2",
+                    color: "#991b1b",
+                  },
+                },
+              }}
+            />
           </QueryClientProvider>
         </api.Provider>
       </SessionProvider>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 import React, { Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import ThemeToggle from "@/components/theme-toggle";
 import { AccountMenu } from "@/components/account-menu";
+import ThemeToggle from "@/components/theme-toggle";
+import { toast } from "@/lib/toast";
 import { api } from "@/server/api/react";
 // Define expected shape of user settings returned by API
-import { toast } from "react-hot-toast";
 
 function SettingsContent() {
   const router = useRouter();
@@ -77,7 +77,7 @@ function SettingsContent() {
   }, [settings]);
   const saveSettings = api.user.setSettings.useMutation({
     onSuccess: () => {
-      toast.success("Settings saved");
+      toast.success("Settings saved.");
       // Prefer explicit returnTo; otherwise, go back. Fallback to /calendar.
       if (returnTo && returnTo.startsWith("/") && !returnTo.startsWith("//")) {
         router.push(returnTo);
@@ -88,7 +88,7 @@ function SettingsContent() {
         setTimeout(() => router.push("/calendar"), 50);
       }
     },
-    onError: (e) => toast.error(e.message || "Failed to save settings"),
+    onError: (e) => toast.error(e.message || "Save failed."),
   });
   const zones = React.useMemo(
     () => (Intl.supportedValuesOf ? Intl.supportedValuesOf("timeZone") : [tz]),

--- a/src/components/new-task-form.test.tsx
+++ b/src/components/new-task-form.test.tsx
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import * as matchers from '@testing-library/jest-dom/matchers';
 expect.extend(matchers);
 import { NewTaskForm } from './new-task-form';
+vi.mock('@/lib/toast', () => ({ toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() } }));
 
 let mutateSpy = vi.fn();
 
@@ -17,7 +18,7 @@ vi.mock('@/server/api/react', () => ({
         useMutation: () => ({
           mutate: (...args: unknown[]) => (mutateSpy as any)(...args),
           isPending: false,
-          error: { message: 'Failed to create task' },
+          error: undefined,
         }),
       },
       update: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },

--- a/src/components/new-task-form.tsx
+++ b/src/components/new-task-form.tsx
@@ -1,10 +1,10 @@
 "use client";
 import React, { useState } from "react";
-import { Button } from "@/components/ui/button";
-import { api } from "@/server/api/react";
-import { toast } from "react-hot-toast";
 import { MoreHorizontal } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { TaskModal } from "@/components/task-modal";
+import { api } from "@/server/api/react";
+import { toast } from "@/lib/toast";
 
 export function NewTaskForm() {
   const utils = api.useUtils();
@@ -17,8 +17,9 @@ export function NewTaskForm() {
       setTitle("");
       setPendingDueAt(null);
       await utils.task.list.invalidate();
+      toast.success("Task added.");
     },
-    onError: (e) => toast.error(e.message || "Failed to create task"),
+    onError: (e) => toast.error(e.message || "Create failed."),
   });
 
   return (

--- a/src/lib/toast.test.ts
+++ b/src/lib/toast.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const base = vi.fn();
+  const success = vi.fn();
+  const error = vi.fn();
+  const dismiss = vi.fn();
+  return { base, success, error, dismiss };
+});
+
+vi.mock("react-hot-toast", () => {
+  const t = Object.assign(mocks.base, {
+    success: mocks.success,
+    error: mocks.error,
+    dismiss: mocks.dismiss,
+  });
+  return { toast: t };
+});
+
+import { toast } from "./toast";
+
+beforeEach(() => {
+  mocks.base.mockReset();
+  mocks.success.mockReset();
+  mocks.error.mockReset();
+  mocks.dismiss.mockReset();
+});
+
+describe("toast utility", () => {
+  it("shows success toast", () => {
+    toast.success("Done.");
+    expect(mocks.dismiss).toHaveBeenCalled();
+    expect(mocks.success).toHaveBeenCalledWith("Done.", { duration: 3500 });
+  });
+
+  it("shows error toast", () => {
+    toast.error("Oops.");
+    expect(mocks.dismiss).toHaveBeenCalled();
+    expect(mocks.error).toHaveBeenCalledWith("Oops.", { duration: 3500 });
+  });
+
+  it("shows info toast", () => {
+    toast.info("FYI.");
+    expect(mocks.dismiss).toHaveBeenCalled();
+    expect(mocks.base).toHaveBeenCalledWith("FYI.", { duration: 3500 });
+  });
+});

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -1,0 +1,18 @@
+import { toast as hotToast } from "react-hot-toast";
+
+const base = { duration: 3500 } as const;
+
+function show(type: "success" | "error" | "info", message: string) {
+  hotToast.dismiss();
+  if (type === "success") return hotToast.success(message, base);
+  if (type === "error") return hotToast.error(message, base);
+  return hotToast(message, base);
+}
+
+export const toast = {
+  success: (msg: string) => show("success", msg),
+  error: (msg: string) => show("error", msg),
+  info: (msg: string) => show("info", msg),
+};
+
+export default toast;


### PR DESCRIPTION
## Summary
- add toast helper with success, error, info variants
- show a single toast at top-right with subtle colors and auto-dismiss
- use new helper in settings and new-task-form

## Testing
- `npm run lint`
- `CI=true npx vitest run src/lib/toast.test.ts`
- `npm run build`
- `CI=true npx vitest run src/lib/toast.test.ts src/components/new-task-form.test.tsx` *(fails: Failed to update status)*

------
https://chatgpt.com/codex/tasks/task_e_68ad283df678832091452ee4024eabfd