### PR TITLE
fix: constrain task list keyboard navigation

### DIFF
--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -78,10 +78,6 @@ test.describe('calendar', () => {
     expect(Math.abs(persistedBox.height - resizedBox.height)).toBeLessThan(5);
   });
 
-<<<<<<< HEAD
-  test('moves event to another slot and persists after reload', async ({ page }) => {
-    const title = `Calendar Move ${Date.now()}`;
-=======
   test('schedules task using custom default duration', async ({ page }) => {
     // set default duration to 60 minutes via settings
     await page.goto('/settings');
@@ -89,7 +85,6 @@ test.describe('calendar', () => {
     await durationInput.fill('60');
 
     const title = `Custom Duration Task ${Date.now()}`;
->>>>>>> origin/main
 
     await page.goto('/');
     const input = page.getByPlaceholder('Add a task…');
@@ -98,57 +93,7 @@ test.describe('calendar', () => {
     await expect(page.getByText(title)).toBeVisible();
 
     await page.goto('/calendar');
-<<<<<<< HEAD
 
-    const task = page.getByRole('button', { name: new RegExp(`focus ${title}`, 'i') });
-    const firstCell = page.locator('[id^="cell-"]').first();
-    const secondCell = page.locator('[id^="cell-"]').nth(1);
-
-    const taskBox = await task.boundingBox();
-    const firstBox = await firstCell.boundingBox();
-    const secondBox = await secondCell.boundingBox();
-    if (!taskBox || !firstBox || !secondBox) throw new Error('missing boxes');
-
-    await page.mouse.move(taskBox.x + taskBox.width / 2, taskBox.y + taskBox.height / 2);
-    await page.mouse.down();
-    await page.mouse.move(firstBox.x + 10, firstBox.y + 10);
-    await page.mouse.up();
-
-    const event = page
-      .locator('[data-testid="calendar-grid"]').locator(`text=${title}`).first();
-    await expect(event).toBeVisible();
-
-    const eventBox = await event.boundingBox();
-    if (!eventBox) throw new Error('missing event box');
-    await page.mouse.move(eventBox.x + eventBox.width / 2, eventBox.y + eventBox.height / 2);
-    await page.mouse.down();
-    await page.mouse.move(secondBox.x + 10, secondBox.y + 10);
-    await page.mouse.up();
-
-    const movedBox = await event.boundingBox();
-    if (!movedBox) throw new Error('missing moved event box');
-    expect(movedBox.x).toBeGreaterThan(eventBox.x);
-
-    const handle = event.locator('[aria-label="resize end"]');
-    const handleBox = await handle.boundingBox();
-    if (!handleBox) throw new Error('missing handle box');
-    await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2);
-    await page.mouse.down();
-    await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2 + 60);
-    await page.mouse.up();
-
-    const resizedBox = await event.boundingBox();
-    if (!resizedBox) throw new Error('missing resized event box');
-    expect(resizedBox.height).toBeGreaterThan(movedBox.height);
-
-    await page.reload();
-    const persisted = page
-      .locator('[data-testid="calendar-grid"]').locator(`text=${title}`).first();
-    const persistedBox = await persisted.boundingBox();
-    if (!persistedBox) throw new Error('missing persisted event box');
-    expect(Math.abs(persistedBox.x - resizedBox.x)).toBeLessThan(5);
-    expect(Math.abs(persistedBox.height - resizedBox.height)).toBeLessThan(5);
-=======
     const task = page.getByRole('button', { name: new RegExp(`focus ${title}`, 'i') });
     const targetCell = page.locator('[id^="cell-"]').first();
 
@@ -166,7 +111,6 @@ test.describe('calendar', () => {
     const box = await event.boundingBox();
     if (!box) throw new Error('missing event box');
     expect(box.height).toBeGreaterThan(40); // 60min ~48px
->>>>>>> origin/main
   });
 
   test('toggles focus with keyboard and updates timer', async ({ page }) => {

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -7,6 +7,16 @@ expect.extend(matchers);
 
 import HomePage from './page';
 
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: { user: { name: 'Test User', image: '' } } }),
+  signOut: () => {},
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(''),
+}));
+
 vi.mock('@/server/api/react', () => ({
   api: {
     useUtils: () => ({ task: { list: { invalidate: () => {} } } }),
@@ -38,10 +48,25 @@ vi.mock('@/server/api/react', () => ({
 }));
 
 describe('HomePage', () => {
-  it('renders search and new task controls', () => {
+  it('renders header with count, filters, search and new task button', () => {
     render(<HomePage />);
+    expect(screen.getByText('Tasks')).toBeInTheDocument();
+    expect(screen.getByText('· 0')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('Search tasks...')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /new task/i })).toBeInTheDocument();
+    ['All', 'Today', 'Overdue'].forEach((label) => {
+      expect(screen.getByRole('button', { name: label })).toBeInTheDocument();
+    });
+  });
+
+  it('shows account menu with Settings and opens dropdown', () => {
+    render(<HomePage />);
+    const acctBtn = screen.getByRole('button', { name: /settings/i });
+    expect(acctBtn).toBeInTheDocument();
+    // open menu
+    acctBtn.click();
+    expect(screen.getByRole('menuitem', { name: /account settings/i })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /sign out/i })).toBeInTheDocument();
   });
 
   it('focuses search on "/" key', () => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,38 +1,37 @@
 "use client";
-import React, { useState, Suspense, useEffect, useRef } from "react";
+
+import React, { useState, useEffect, Suspense, useRef } from "react";
 import { TaskList } from "@/components/task-list";
-import { TaskFilterTabs } from "@/components/task-filter-tabs";
 import { TaskModal } from "@/components/task-modal";
 import { Button } from "@/components/ui/button";
-import ThemeToggle from "@/components/theme-toggle";
+import { clsx } from "clsx";
 import { AccountMenu } from "@/components/account-menu";
+import ThemeToggle from "@/components/theme-toggle";
 import { ShortcutsPopover } from "@/components/shortcuts-popover";
 
 type Priority = "LOW" | "MEDIUM" | "HIGH";
 
 export default function HomePage() {
-  const [filter, setFilter] = useState<"all" | "overdue" | "today" | "archive">("all");
-  const [subject, setSubject] = useState<string | null>(null);
-  const [priority, setPriority] = useState<Priority | null>(null);
-  const [courseId, setCourseId] = useState<string | null>(null);
-  const [projectId, setProjectId] = useState<string | null>(null);
+  const [filter, setFilter] = useState<"all" | "overdue" | "today">("all");
+  const [subject] = useState<string | null>(null);
+  const [priority] = useState<Priority | null>(null);
+  const [courseId] = useState<string | null>(null);
+  const [projectId] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [showModal, setShowModal] = useState(false);
+  const [taskCount, setTaskCount] = useState(0);
   const searchRef = useRef<HTMLInputElement>(null);
 
-  // Global hotkeys
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.defaultPrevented) return;
-      // Ignore when typing in inputs/textareas or contenteditable
       const target = e.target as HTMLElement | null;
       const tag = target?.tagName?.toLowerCase();
       const isEditable =
         tag === "input" ||
         tag === "textarea" ||
-        (target && (target as HTMLElement).isContentEditable);
+        (target && target.isContentEditable);
       if (isEditable) return;
-      // Only plain "n" without modifiers
       if (e.key.toLowerCase() === "n" && !e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey) {
         e.preventDefault();
         setShowModal(true);
@@ -43,12 +42,7 @@ export default function HomePage() {
       }
       if ((e.key === "ArrowRight" || e.key === "ArrowLeft") && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
-        const options: Array<"all" | "overdue" | "today" | "archive"> = [
-          "all",
-          "overdue",
-          "today",
-          "archive",
-        ];
+        const options: Array<"all" | "overdue" | "today"> = ["all", "today", "overdue"];
         const idx = options.indexOf(filter);
         const nextIndex =
           e.key === "ArrowRight"
@@ -64,40 +58,51 @@ export default function HomePage() {
   return (
     <>
       <header className="sticky top-0 z-10 border-b bg-white/80 backdrop-blur dark:bg-slate-950/80">
-        <div className="mx-auto max-w-4xl space-y-4 px-3.5 py-2.5 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between">
-            <h1 className="text-2xl font-semibold">Tasks</h1>
-            <div className="flex items-center gap-3">
-              <Button onClick={() => setShowModal(true)}>New task</Button>
+        <div className="mx-auto max-w-4xl px-3.5 py-2.5 sm:px-6 lg:px-8">
+          <div className="flex flex-col items-center gap-3 md:flex-row md:gap-4">
+            <div className="flex items-center gap-2 md:mr-auto">
+              <h1 className="text-2xl font-semibold">Tasks</h1>
+              <span className="text-sm text-muted-foreground">· {taskCount}</span>
+            </div>
+            <div className="order-last flex items-center gap-2 md:order-none md:ml-auto">
+              <input
+                ref={searchRef}
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.currentTarget.value)}
+                placeholder="Search tasks..."
+                className="h-9 w-40 md:w-80 rounded-md border bg-transparent px-3 text-sm outline-none placeholder:text-muted-foreground"
+              />
+              <Button className="h-9" onClick={() => setShowModal(true)}>
+                + New Task
+              </Button>
               <ShortcutsPopover />
               <ThemeToggle />
-              <Suspense fallback={null}>
+              <Suspense fallback={<div aria-hidden className="h-9 w-9 rounded-full bg-black/10 dark:bg-white/10 animate-pulse" />}>
                 <AccountMenu />
               </Suspense>
             </div>
+            <div className="flex justify-center md:mx-auto">
+              <div className="inline-flex rounded-lg border bg-white p-1">
+                {[
+                  { key: "all", label: "All" },
+                  { key: "today", label: "Today" },
+                  { key: "overdue", label: "Overdue" },
+                ].map((tab) => (
+                  <button
+                    key={tab.key}
+                    onClick={() => setFilter(tab.key as any)}
+                    className={clsx(
+                      "rounded-md px-3 py-1 text-sm",
+                      filter === tab.key && "bg-neutral-100"
+                    )}
+                  >
+                    {tab.label}
+                  </button>
+                ))}
+              </div>
+            </div>
           </div>
-          <div className="flex items-center gap-3">
-            <input
-              type="text"
-              value={query}
-              onChange={(e) => setQuery(e.currentTarget.value)}
-              placeholder="Search tasks..."
-              className="flex-1 rounded-md border bg-transparent px-3.5 py-2.5 text-sm outline-none placeholder:text-muted-foreground"
-              ref={searchRef}
-            />
-          </div>
-          <TaskFilterTabs
-            value={filter}
-            onChange={setFilter}
-            subject={subject}
-            onSubjectChange={setSubject}
-            priority={priority}
-            onPriorityChange={setPriority}
-            courseId={courseId}
-            onCourseChange={setCourseId}
-            projectId={projectId}
-            onProjectChange={setProjectId}
-          />
         </div>
       </header>
       <main className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8 py-6">
@@ -109,6 +114,7 @@ export default function HomePage() {
             courseId={courseId}
             projectId={projectId}
             query={query}
+            onCountChange={setTaskCount}
           />
         </div>
       </main>
@@ -116,3 +122,4 @@ export default function HomePage() {
     </>
   );
 }
+

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -6,8 +6,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { httpBatchLink } from "@trpc/client";
 import superjson from "superjson";
 import { Toaster } from "react-hot-toast";
-import { api } from "@/server/api/react";
 import { SessionProvider } from "next-auth/react";
+import { api } from "@/server/api/react";
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = React.useState(() => new QueryClient());
@@ -29,7 +29,28 @@ export default function Providers({ children }: { children: React.ReactNode }) {
         <api.Provider client={trpcClient} queryClient={queryClient}>
           <QueryClientProvider client={queryClient}>
             {children}
-            <Toaster />
+            <Toaster
+              position="top-right"
+              toastOptions={{
+                duration: 3500,
+                style: {
+                  background: "#f3f4f6",
+                  color: "#374151",
+                },
+                success: {
+                  style: {
+                    background: "#dcfce7",
+                    color: "#166534",
+                  },
+                },
+                error: {
+                  style: {
+                    background: "#fee2e2",
+                    color: "#991b1b",
+                  },
+                },
+              }}
+            />
           </QueryClientProvider>
         </api.Provider>
       </SessionProvider>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 import React, { Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import ThemeToggle from "@/components/theme-toggle";
 import { AccountMenu } from "@/components/account-menu";
+import ThemeToggle from "@/components/theme-toggle";
+import { toast } from "@/lib/toast";
 import { api } from "@/server/api/react";
 // Define expected shape of user settings returned by API
-import { toast } from "react-hot-toast";
 
 function SettingsContent() {
   const router = useRouter();
@@ -77,7 +77,7 @@ function SettingsContent() {
   }, [settings]);
   const saveSettings = api.user.setSettings.useMutation({
     onSuccess: () => {
-      toast.success("Settings saved");
+      toast.success("Settings saved.");
       // Prefer explicit returnTo; otherwise, go back. Fallback to /calendar.
       if (returnTo && returnTo.startsWith("/") && !returnTo.startsWith("//")) {
         router.push(returnTo);
@@ -88,7 +88,7 @@ function SettingsContent() {
         setTimeout(() => router.push("/calendar"), 50);
       }
     },
-    onError: (e) => toast.error(e.message || "Failed to save settings"),
+    onError: (e) => toast.error(e.message || "Save failed."),
   });
   const zones = React.useMemo(
     () => (Intl.supportedValuesOf ? Intl.supportedValuesOf("timeZone") : [tz]),

--- a/src/components/account-menu.tsx
+++ b/src/components/account-menu.tsx
@@ -41,25 +41,25 @@ export function AccountMenu() {
         aria-haspopup="menu"
         aria-expanded={open}
         onClick={() => setOpen((v) => !v)}
-        className="inline-flex items-center gap-2 rounded border px-2 py-1 text-sm hover:bg-black/5 dark:hover:bg-white/5"
-        title="Account menu"
+        className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-transparent p-0 hover:bg-black/5 dark:hover:bg-white/10"
+        aria-label="Account menu"
+        title={user?.name ? `${user.name} — Account menu` : "Account menu"}
       >
         {user?.image ? (
           // eslint-disable-next-line @next/next/no-img-element
-          <img src={user.image} alt={user?.name ?? "Account"} className="h-6 w-6 rounded-full" />
+          <img src={user.image} alt={user?.name ?? "Account"} className="h-9 w-9 rounded-full object-cover" />
         ) : (
-          <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-black/10 text-xs dark:bg-white/10">
+          <span className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-black/10 text-xs dark:bg-white/10">
             {initials || ""}
           </span>
         )}
-        <span className="hidden sm:inline">Settings</span>
       </button>
 
       {open && (
         <div
           role="menu"
           aria-label="Account menu"
-          className="absolute right-0 z-10 mt-2 w-48 rounded border bg-white p-1 text-sm shadow-lg dark:border-white/10 dark:bg-zinc-900"
+          className="absolute right-0 z-10 mt-2 w-56 rounded border bg-white p-1 text-sm shadow-lg dark:border-white/10 dark:bg-zinc-900"
         >
           <Link
             role="menuitem"

--- a/src/components/new-task-form.test.tsx
+++ b/src/components/new-task-form.test.tsx
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import * as matchers from '@testing-library/jest-dom/matchers';
 expect.extend(matchers);
 import { NewTaskForm } from './new-task-form';
+vi.mock('@/lib/toast', () => ({ toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() } }));
 
 let mutateSpy = vi.fn();
 
@@ -17,7 +18,7 @@ vi.mock('@/server/api/react', () => ({
         useMutation: () => ({
           mutate: (...args: unknown[]) => (mutateSpy as any)(...args),
           isPending: false,
-          error: { message: 'Failed to create task' },
+          error: undefined,
         }),
       },
       update: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },

--- a/src/components/new-task-form.tsx
+++ b/src/components/new-task-form.tsx
@@ -1,10 +1,10 @@
 "use client";
 import React, { useState } from "react";
-import { Button } from "@/components/ui/button";
-import { api } from "@/server/api/react";
-import { toast } from "react-hot-toast";
 import { MoreHorizontal } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { TaskModal } from "@/components/task-modal";
+import { api } from "@/server/api/react";
+import { toast } from "@/lib/toast";
 
 export function NewTaskForm() {
   const utils = api.useUtils();
@@ -17,8 +17,9 @@ export function NewTaskForm() {
       setTitle("");
       setPendingDueAt(null);
       await utils.task.list.invalidate();
+      toast.success("Task added.");
     },
-    onError: (e) => toast.error(e.message || "Failed to create task"),
+    onError: (e) => toast.error(e.message || "Create failed."),
   });
 
   return (

--- a/src/components/status-dropdown.test.tsx
+++ b/src/components/status-dropdown.test.tsx
@@ -1,0 +1,22 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+expect.extend(matchers);
+import { StatusDropdown } from './status-dropdown';
+
+describe('StatusDropdown', () => {
+  it('uses soft background colors for each status', () => {
+    const { rerender } = render(
+      <StatusDropdown value="TODO" onChange={() => {}} />
+    );
+    expect(screen.getByRole('button')).toHaveClass('bg-neutral-100');
+
+    rerender(<StatusDropdown value="IN_PROGRESS" onChange={() => {}} />);
+    expect(screen.getByRole('button')).toHaveClass('bg-amber-50');
+
+    rerender(<StatusDropdown value="DONE" onChange={() => {}} />);
+    expect(screen.getByRole('button')).toHaveClass('bg-emerald-50');
+  });
+});

--- a/src/components/status-dropdown.tsx
+++ b/src/components/status-dropdown.tsx
@@ -12,19 +12,21 @@ const STATUS_LABELS: Record<TaskStatus, string> = {
 };
 
 const STATUS_STYLES: Record<TaskStatus, string> = {
-  TODO: "bg-slate-100 text-slate-700 ring-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:ring-slate-700",
+  TODO:
+    "bg-neutral-100 text-neutral-700 ring-neutral-200 dark:bg-neutral-800 dark:text-neutral-200 dark:ring-neutral-700",
   IN_PROGRESS:
-    "bg-blue-100 text-blue-700 ring-blue-200 dark:bg-blue-900/30 dark:text-blue-200 dark:ring-blue-800",
-  DONE: "bg-emerald-100 text-emerald-700 ring-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-200 dark:ring-emerald-800",
+    "bg-amber-50 text-amber-700 ring-amber-200 dark:bg-amber-900/30 dark:text-amber-200 dark:ring-amber-800",
+  DONE:
+    "bg-emerald-50 text-emerald-700 ring-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-200 dark:ring-emerald-800",
   CANCELLED:
-    "bg-gray-100 text-gray-700 ring-gray-200 dark:bg-gray-900/30 dark:text-gray-200 dark:ring-gray-700",
+    "bg-neutral-100 text-neutral-500 ring-neutral-200 dark:bg-neutral-800 dark:text-neutral-400 dark:ring-neutral-700",
 };
 
 const DOT_STYLES: Record<TaskStatus, string> = {
-  TODO: "bg-slate-500",
-  IN_PROGRESS: "bg-blue-500",
+  TODO: "bg-neutral-400",
+  IN_PROGRESS: "bg-amber-500",
   DONE: "bg-emerald-500",
-  CANCELLED: "bg-gray-400",
+  CANCELLED: "bg-neutral-400",
 };
 
 export interface StatusDropdownProps {

--- a/src/components/tags.test.tsx
+++ b/src/components/tags.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+import { Tags } from './tags';
+
+expect.extend(matchers);
+
+describe('Tags component', () => {
+  it('renders all tags when under the limit', () => {
+    render(<Tags items={['math', 'science', 'english']} />);
+    expect(screen.queryByText('+')).not.toBeInTheDocument();
+    expect(screen.getByText('math')).toBeInTheDocument();
+    expect(screen.getByText('science')).toBeInTheDocument();
+    expect(screen.getByText('english')).toBeInTheDocument();
+  });
+
+  it('shows a +N counter when tags exceed the limit', () => {
+    render(
+      <Tags items={['a', 'b', 'c', 'd', 'e', 'f']} maxVisible={4} />
+    );
+    expect(screen.getByText('+2')).toBeInTheDocument();
+  });
+});

--- a/src/components/tags.tsx
+++ b/src/components/tags.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+interface TagsProps {
+  /** List of tag labels to display */
+  items: string[];
+  /** Maximum number of tags to show before collapsing into a "+N" counter. Defaults to 5. */
+  maxVisible?: number;
+}
+
+/**
+ * Displays a list of tags as small rounded pills. When the number of tags
+ * exceeds `maxVisible`, the remaining count is summarized as a "+N" pill.
+ */
+export function Tags({ items, maxVisible = 5 }: TagsProps) {
+  const visible = items.slice(0, maxVisible);
+  const hiddenCount = items.length - visible.length;
+
+  return (
+    <div className="flex flex-wrap gap-1 text-[11px]">
+      {visible.map((tag) => (
+        <span
+          key={tag}
+          className="px-2 py-0.5 rounded-full bg-neutral-100"
+        >
+          {tag}
+        </span>
+      ))}
+      {hiddenCount > 0 && (
+        <span className="px-2 py-0.5 rounded-full bg-neutral-100">+{hiddenCount}</span>
+      )}
+    </div>
+  );
+}
+
+export default Tags;

--- a/src/components/task-list.test.tsx
+++ b/src/components/task-list.test.tsx
@@ -15,12 +15,15 @@ vi.mock('@/server/api/react', () => ({
       list: {
         useInfiniteQuery: (...args: any[]) => useInfiniteQueryMock(...args),
       },
+      create: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },
       update: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },
       setDueDate: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },
       delete: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },
       setStatus: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },
       reorder: { useMutation: () => ({ mutate: vi.fn(), isPending: false, error: undefined }) },
     },
+    project: { list: { useQuery: () => ({ data: [], isLoading: false, error: undefined }) } },
+    course: { list: { useQuery: () => ({ data: [], isLoading: false, error: undefined }) } },
     user: { get: { useQuery: () => ({ data: null, isLoading: false, error: undefined }) } },
   },
 }));
@@ -50,10 +53,12 @@ describe('TaskList', () => {
 
   it('moves selection with j key', () => {
     useInfiniteQueryMock.mockReturnValue({
-      data: { pages: [[
-        { id: '1', title: 'Alpha', dueAt: null, status: 'TODO' },
-        { id: '2', title: 'Beta', dueAt: null, status: 'TODO' },
-      ]] },
+      data: {
+        pages: [[
+          { id: '1', title: 'Alpha', dueAt: null, status: 'TODO' },
+          { id: '2', title: 'Beta', dueAt: null, status: 'TODO' },
+        ]],
+      },
       isLoading: false,
       error: undefined,
       fetchNextPage: vi.fn(),
@@ -70,9 +75,91 @@ describe('TaskList', () => {
         query=""
       />
     );
+    const list = screen.getByRole('listbox');
     const items = screen.getAllByRole('option');
     expect(items[0]).toHaveAttribute('aria-selected', 'true');
-    fireEvent.keyDown(window, { key: 'j' });
+    fireEvent.keyDown(list, { key: 'j' });
     expect(items[1]).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('shows red due date text for overdue tasks', () => {
+    const now = new Date('2023-01-02T12:00:00Z');
+    vi.setSystemTime(now);
+    useInfiniteQueryMock.mockReturnValue({
+      data: {
+        pages: [[{ id: '1', title: 'Alpha', dueAt: new Date('2023-01-01T12:00:00Z'), status: 'TODO' }]],
+      },
+      isLoading: false,
+      error: undefined,
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+    render(
+      <TaskList
+        filter="all"
+        subject={null}
+        priority={null}
+        courseId={null}
+        projectId={null}
+        query=""
+      />
+    );
+    expect(screen.getByTestId('due-date')).toHaveClass('text-red-600');
+    vi.useRealTimers();
+  });
+
+  it('shows amber due date text for tasks due today', () => {
+    const now = new Date('2023-01-02T12:00:00Z');
+    vi.setSystemTime(now);
+    useInfiniteQueryMock.mockReturnValue({
+      data: {
+        pages: [[{ id: '1', title: 'Alpha', dueAt: new Date('2023-01-02T15:00:00Z'), status: 'TODO' }]],
+      },
+      isLoading: false,
+      error: undefined,
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+    render(
+      <TaskList
+        filter="all"
+        subject={null}
+        priority={null}
+        courseId={null}
+        projectId={null}
+        query=""
+      />
+    );
+    expect(screen.getByTestId('due-date')).toHaveClass('text-amber-600');
+    vi.useRealTimers();
+  });
+
+  it('shows neutral due date text for future tasks', () => {
+    const now = new Date('2023-01-02T12:00:00Z');
+    vi.setSystemTime(now);
+    useInfiniteQueryMock.mockReturnValue({
+      data: {
+        pages: [[{ id: '1', title: 'Alpha', dueAt: new Date('2023-01-03T12:00:00Z'), status: 'TODO' }]],
+      },
+      isLoading: false,
+      error: undefined,
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+    render(
+      <TaskList
+        filter="all"
+        subject={null}
+        priority={null}
+        courseId={null}
+        projectId={null}
+        query=""
+      />
+    );
+    expect(screen.getByTestId('due-date')).toHaveClass('text-neutral-500');
+    vi.useRealTimers();
   });
 });

--- a/src/components/task-modal.tsx
+++ b/src/components/task-modal.tsx
@@ -116,14 +116,14 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
     <>
       {isEdit && task && (
         <Button
-          variant="danger"
+          variant="destructive"
           className="mr-auto"
           onClick={() => del.mutate({ id: task.id })}
         >
           Delete
         </Button>
       )}
-      <Button variant="secondary" onClick={onClose}>
+      <Button variant="tertiary" onClick={onClose}>
         Cancel
       </Button>
       <Button
@@ -176,10 +176,10 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
 
   return (
     <Modal open={open} onClose={onClose} title={isEdit ? "Edit Task" : "New Task"} footer={footer}>
-      <div className="grid grid-cols-1 gap-3">
+      <div className="flex flex-col gap-6">
         {isEdit && task && (
-          <div className="flex items-center justify-between">
-            <span className="text-xs uppercase tracking-wide opacity-60">Status</span>
+          <div className="flex items-center gap-4">
+            <span className="w-28 text-sm font-medium">Status</span>
             <StatusDropdown
               value={task.status ?? "TODO"}
               onChange={(next) => {
@@ -189,48 +189,55 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
             />
           </div>
         )}
-        <label className="flex flex-col gap-1">
-          <span className="text-xs uppercase tracking-wide opacity-60">Title</span>
+        <div className="flex items-center gap-4">
+          <label htmlFor="title" className="w-28 text-sm font-medium">
+            Title
+          </label>
           <input
-            className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+            id="title"
+            className="flex-1 rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
             placeholder="Task title"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
           />
-        </label>
+        </div>
 
-        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-          <label className="flex flex-col gap-1">
-            <span className="text-xs uppercase tracking-wide opacity-60">Subject</span>
-            <input
-              className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
-              placeholder="e.g., Math, CS, English"
-              value={subject}
-              onChange={(e) => setSubject(e.target.value)}
-            />
+        <div className="flex items-center gap-4">
+          <label htmlFor="subject" className="w-28 text-sm font-medium">
+            Subject
           </label>
-          <div className="flex flex-col gap-1">
-            <label className="flex items-center gap-2 text-xs uppercase tracking-wide opacity-60">
-              <input
-                type="checkbox"
-                className="accent-black dark:accent-white"
-                checked={dueEnabled}
-                onChange={(e) => {
-                  const enabled = e.target.checked;
-                  setDueEnabled(enabled);
-                  if (enabled && !due) {
-                    const v = defaultEndOfToday();
-                    setDue(v);
-                    onDraftDueChange?.(parseLocalDateTime(v));
-                  }
-                  if (!enabled) onDraftDueChange?.(null);
-                }}
-              />
-              Set due date
-            </label>
+          <input
+            id="subject"
+            className="flex-1 rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+            placeholder="e.g., Math, CS, English"
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+          />
+        </div>
+        <div className="flex items-center gap-4">
+          <span className="w-28 text-sm font-medium">Due date</span>
+          <div className="flex flex-1 items-center gap-2">
             <input
+              id="due-enabled"
+              type="checkbox"
+              className="accent-black dark:accent-white"
+              checked={dueEnabled}
+              aria-label="Set due date"
+              onChange={(e) => {
+                const enabled = e.target.checked;
+                setDueEnabled(enabled);
+                if (enabled && !due) {
+                  const v = defaultEndOfToday();
+                  setDue(v);
+                  onDraftDueChange?.(parseLocalDateTime(v));
+                }
+                if (!enabled) onDraftDueChange?.(null);
+              }}
+            />
+            <input
+              id="due"
               type="datetime-local"
-              className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 disabled:opacity-50 dark:border-white/10 dark:focus:ring-white/20"
+              className="flex-1 rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 disabled:opacity-50 dark:border-white/10 dark:focus:ring-white/20"
               value={due}
               onChange={(e) => {
                 setDue(e.target.value);
@@ -240,42 +247,49 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
             />
           </div>
         </div>
-        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-          <label className="flex flex-col gap-1">
-            <span className="text-xs uppercase tracking-wide opacity-60">Project</span>
-            <select
-              className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
-              value={projectId ?? ""}
-              onChange={(e) => setProjectId(e.target.value || null)}
-            >
-              <option value="">None</option>
-              {projects.map((p) => (
-                <option key={p.id} value={p.id}>
-                  {p.title}
-                </option>
-              ))}
-            </select>
+        <div className="flex items-center gap-4">
+          <label htmlFor="project" className="w-28 text-sm font-medium">
+            Project
           </label>
-          <label className="flex flex-col gap-1">
-            <span className="text-xs uppercase tracking-wide opacity-60">Course</span>
-            <select
-              className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
-              value={courseId ?? ""}
-              onChange={(e) => setCourseId(e.target.value || null)}
-            >
-              <option value="">None</option>
-              {courses.map((c) => (
-                <option key={c.id} value={c.id}>
-                  {c.title}
-                </option>
-              ))}
-            </select>
-          </label>
-        </div>
-        <label className="flex flex-col gap-1">
-          <span className="text-xs uppercase tracking-wide opacity-60">Priority</span>
           <select
-            className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+            id="project"
+            className="flex-1 rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+            value={projectId ?? ""}
+            onChange={(e) => setProjectId(e.target.value || null)}
+          >
+            <option value="">None</option>
+            {projects.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.title}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="flex items-center gap-4">
+          <label htmlFor="course" className="w-28 text-sm font-medium">
+            Course
+          </label>
+          <select
+            id="course"
+            className="flex-1 rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+            value={courseId ?? ""}
+            onChange={(e) => setCourseId(e.target.value || null)}
+          >
+            <option value="">None</option>
+            {courses.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.title}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="flex items-center gap-4">
+          <label htmlFor="priority" className="w-28 text-sm font-medium">
+            Priority
+          </label>
+          <select
+            id="priority"
+            className="flex-1 rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
             value={priority}
             onChange={(e) => setPriority(e.target.value as Task["priority"])}
           >
@@ -283,72 +297,85 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
             <option value="MEDIUM">Medium</option>
             <option value="HIGH">High</option>
           </select>
-        </label>
-
-        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-          <label className="flex flex-col gap-1">
-            <span className="text-xs uppercase tracking-wide opacity-60">Recurrence</span>
-            <select
-              className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
-              value={recurrenceType}
-              onChange={(e) => setRecurrenceType(e.target.value as typeof recurrenceType)}
-            >
-              <option value="NONE">None</option>
-              <option value="DAILY">Daily</option>
-              <option value="WEEKLY">Weekly</option>
-              <option value="MONTHLY">Monthly</option>
-            </select>
-          </label>
-          {recurrenceType !== 'NONE' && (
-            <label className="flex flex-col gap-1">
-              <span className="text-xs uppercase tracking-wide opacity-60">Interval</span>
-              <input
-                type="number"
-                min={1}
-                className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
-                value={recurrenceInterval}
-                onChange={(e) => setRecurrenceInterval(parseInt(e.target.value, 10) || 1)}
-              />
-            </label>
-          )}
         </div>
 
+        <div className="flex items-center gap-4">
+          <label htmlFor="recurrenceType" className="w-28 text-sm font-medium">
+            Recurrence
+          </label>
+          <select
+            id="recurrenceType"
+            className="flex-1 rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+            value={recurrenceType}
+            onChange={(e) => setRecurrenceType(e.target.value as typeof recurrenceType)}
+          >
+            <option value="NONE">None</option>
+            <option value="DAILY">Daily</option>
+            <option value="WEEKLY">Weekly</option>
+            <option value="MONTHLY">Monthly</option>
+          </select>
+        </div>
         {recurrenceType !== 'NONE' && (
-          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-            <label className="flex flex-col gap-1">
-              <span className="text-xs uppercase tracking-wide opacity-60">End after occurrences</span>
+          <div className="flex items-center gap-4">
+            <label htmlFor="recurrenceInterval" className="w-28 text-sm font-medium">
+              Interval
+            </label>
+            <input
+              id="recurrenceInterval"
+              type="number"
+              min={1}
+              className="flex-1 rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+              value={recurrenceInterval}
+              onChange={(e) => setRecurrenceInterval(parseInt(e.target.value, 10) || 1)}
+            />
+          </div>
+        )}
+
+        {recurrenceType !== 'NONE' && (
+          <>
+            <div className="flex items-center gap-4">
+              <label htmlFor="recurrenceCount" className="w-28 text-sm font-medium">
+                End after
+              </label>
               <input
+                id="recurrenceCount"
                 type="number"
                 min={1}
-                className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+                className="flex-1 rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
                 value={recurrenceCount}
                 onChange={(e) =>
                   setRecurrenceCount(e.target.value ? parseInt(e.target.value, 10) : '')
                 }
               />
-            </label>
-            <label className="flex flex-col gap-1">
-              <span className="text-xs uppercase tracking-wide opacity-60">End on date</span>
+            </div>
+            <div className="flex items-center gap-4">
+              <label htmlFor="recurrenceUntil" className="w-28 text-sm font-medium">
+                End on
+              </label>
               <input
+                id="recurrenceUntil"
                 type="date"
-                className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+                className="flex-1 rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
                 value={recurrenceUntil}
                 onChange={(e) => setRecurrenceUntil(e.target.value)}
               />
-            </label>
-          </div>
+            </div>
+          </>
         )}
 
-        <label className="flex flex-col gap-1">
-          <span className="text-xs uppercase tracking-wide opacity-60">Notes</span>
+        <div className="flex items-start gap-4">
+          <label htmlFor="notes" className="w-28 text-sm font-medium">
+            Notes
+          </label>
           <textarea
+            id="notes"
             rows={4}
-            className="resize-none rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+            className="flex-1 resize-none rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
             placeholder="Optional details…"
             value={notes}
             onChange={(e) => setNotes(e.target.value)}
           />
-        </label>
+        </div>
       </div>
     </Modal>
   );

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { clsx } from 'clsx';
 
-export type ButtonVariant = 'primary' | 'secondary' | 'danger';
+export type ButtonVariant =
+  | 'primary'
+  | 'secondary'
+  | 'danger'
+  | 'destructive'
+  | 'tertiary';
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: ButtonVariant;
@@ -19,6 +24,10 @@ export function Button({
     secondary:
       'bg-gray-100 text-gray-900 border border-gray-300 dark:bg-gray-800 dark:text-gray-100 dark:border-gray-700',
     danger: 'bg-red-600 text-white hover:bg-red-700 dark:bg-red-700',
+    destructive:
+      'border border-red-600 text-red-600 hover:bg-red-50 dark:text-red-400 dark:border-red-400 dark:hover:bg-red-900/20',
+    tertiary:
+      'text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800',
   };
 
   return (

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -67,7 +67,7 @@ export function Modal({ open, onClose, title, children, footer }: ModalProps) {
   return (
     <div
       ref={dialogRef}
-      className="fixed inset-0 z-50 flex items-center justify-center"
+      className="fixed inset-0 z-50 flex items-end justify-center md:items-center"
       aria-modal="true"
       role="dialog"
       aria-labelledby={title ? titleId : undefined}
@@ -78,7 +78,7 @@ export function Modal({ open, onClose, title, children, footer }: ModalProps) {
         className="absolute inset-0 bg-black/40 backdrop-blur-sm"
         onClick={onClose}
       />
-      <div className="relative z-10 w-full max-w-lg rounded-xl border border-black/10 bg-white/90 p-4 shadow-2xl dark:border-white/10 dark:bg-neutral-900/90">
+      <div className="relative z-10 w-full rounded-t-xl border border-black/10 bg-white/90 p-4 shadow-2xl animate-slide-up dark:border-white/10 dark:bg-neutral-900/90 md:max-w-lg md:rounded-xl">
         {title && (
           <div
             id={titleId}

--- a/src/lib/toast.test.ts
+++ b/src/lib/toast.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const base = vi.fn();
+  const success = vi.fn();
+  const error = vi.fn();
+  const dismiss = vi.fn();
+  return { base, success, error, dismiss };
+});
+
+vi.mock("react-hot-toast", () => {
+  const t = Object.assign(mocks.base, {
+    success: mocks.success,
+    error: mocks.error,
+    dismiss: mocks.dismiss,
+  });
+  return { toast: t };
+});
+
+import { toast } from "./toast";
+
+beforeEach(() => {
+  mocks.base.mockReset();
+  mocks.success.mockReset();
+  mocks.error.mockReset();
+  mocks.dismiss.mockReset();
+});
+
+describe("toast utility", () => {
+  it("shows success toast", () => {
+    toast.success("Done.");
+    expect(mocks.dismiss).toHaveBeenCalled();
+    expect(mocks.success).toHaveBeenCalledWith("Done.", { duration: 3500 });
+  });
+
+  it("shows error toast", () => {
+    toast.error("Oops.");
+    expect(mocks.dismiss).toHaveBeenCalled();
+    expect(mocks.error).toHaveBeenCalledWith("Oops.", { duration: 3500 });
+  });
+
+  it("shows info toast", () => {
+    toast.info("FYI.");
+    expect(mocks.dismiss).toHaveBeenCalled();
+    expect(mocks.base).toHaveBeenCalledWith("FYI.", { duration: 3500 });
+  });
+});

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -1,0 +1,18 @@
+import { toast as hotToast } from "react-hot-toast";
+
+const base = { duration: 3500 } as const;
+
+function show(type: "success" | "error" | "info", message: string) {
+  hotToast.dismiss();
+  if (type === "success") return hotToast.success(message, base);
+  if (type === "error") return hotToast.error(message, base);
+  return hotToast(message, base);
+}
+
+export const toast = {
+  success: (msg: string) => show("success", msg),
+  error: (msg: string) => show("error", msg),
+  info: (msg: string) => show("info", msg),
+};
+
+export default toast;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,3 +2,13 @@
 @tailwind components;
 @tailwind utilities;
 html, body, #__next { height: 100%; }
+
+@layer utilities {
+  @keyframes slide-up {
+    from { transform: translateY(100%); }
+    to { transform: translateY(0); }
+  }
+  .animate-slide-up {
+    animation: slide-up 0.3s ease-out;
+  }
+}

--- a/style.md
+++ b/style.md
@@ -1,0 +1,116 @@
+# Student Task Scheduler – UI Style Guide
+
+This document defines visual and interaction guidelines for the app. Follow these conventions for a consistent, accessible, and clean UI.
+
+## Design Principles
+
+- Clarity: Prioritize legibility and simple layouts.
+- Restraint: Minimal chrome; let content carry the weight.
+- Consistency: Reuse components and spacing tokens.
+- Accessibility: Sufficient contrast, clear focus states, keyboard support.
+
+## Foundations
+
+### Colors
+
+- Light theme base: `bg-white`, `text-zinc-900`, subtle borders `border-zinc-200`.
+- Dark theme base: `bg-zinc-900`, `text-zinc-100`, borders `border-white/10`.
+- Muted text: `text-muted-foreground` via Tailwind config or `text-zinc-500`.
+- Accents: Prefer neutral emphasis; avoid bright brand colors in core UI.
+
+### Spacing & Radii
+
+- Spacing scale: Tailwind defaults; common vertical rhythm uses `py-2.5`, `py-3`, `gap-2`, `gap-3`.
+- Container width: content max at `max-w-4xl` with side padding `px-4 sm:px-6 lg:px-8`.
+- Radius: `rounded-md` for inputs/buttons; `rounded-lg`/`rounded-xl` for cards.
+
+### Typography
+
+- Base: System font stack via Tailwind. Keep sizes small-to-medium.
+- Headings: `text-2xl font-semibold` for page titles; `text-lg font-medium` for sections.
+- Body: `text-sm` for controls and dense layouts.
+
+### Elevation & Borders
+
+- Cards: `border` + subtle `shadow-sm` for primary containers.
+- Menus: `rounded` + `shadow-lg`; thin borders for dark theme: `dark:border-white/10`.
+
+### Light/Dark
+
+- Use `next-themes` with `ThemeToggle` in the header.
+- Ensure foreground/background pairs have WCAG AA contrast.
+- Provide skeletons/placeholders that adapt to theme (e.g., `bg-black/10` vs `dark:bg-white/10`).
+
+## Layouts
+
+### App Header (Top Bar)
+
+- Composition: Title + count on left; search input, primary action, theme toggle, account avatar on the right.
+- Behavior: Sticky with blur: `sticky top-0 z-10 border-b bg-white/80 backdrop-blur dark:bg-slate-950/80`.
+- Right cluster order: search → primary action → theme toggle → account avatar.
+- Account avatar uses the user’s Google profile image when available; otherwise initials.
+
+### Content Area
+
+- Page padding: `py-6` with side paddings `px-4 sm:px-6 lg:px-8`.
+- Primary card: `rounded-xl border bg-white dark:bg-zinc-900 shadow-sm p-4`.
+
+## Components
+
+### Buttons
+
+- Variants:
+  - Primary: `bg-black text-white dark:bg-white dark:text-black`.
+  - Secondary: `bg-gray-100 text-gray-900 border border-gray-300 dark:bg-gray-800 dark:text-gray-100 dark:border-gray-700`.
+  - Danger: `bg-red-600 text-white hover:bg-red-700 dark:bg-red-700`.
+- Sizing: Default height `h-9` in dense toolbars; horizontal padding `px-3`–`px-4`.
+- Shape: `rounded-md`. Avoid pill shapes unless clearly needed.
+- Focus: Always show visible ring: `focus-visible:ring-2 focus-visible:ring-indigo-500` for interactive icon buttons.
+
+### Primary Action (New Task)
+
+- Placement: Right cluster, after search.
+- Size: `h-9`; text `text-sm`; padding `px-3`–`px-4`.
+- Label: “+ New Task”. Avoid emojis; keep concise.
+- Behavior: Opens Task Modal; also bind global hotkey “n”.
+
+### Text Input (Search)
+
+- Size: `h-9` with `rounded-md border px-3 text-sm`.
+- Widths: `w-40 md:w-80`.
+- Placeholder: “Search tasks…”. Avoid extra adornments unless necessary.
+
+### Theme Toggle
+
+- Icon-only button `h-9 w-9`, rounded, subtle hover bg.
+- Taps between light/dark; persists in `localStorage`.
+
+### Account Menu (Settings)
+
+- Trigger: Icon-only avatar at top-right. Use user’s Google profile image (`user.image`) when present; fall back to initials in a neutral circle.
+- Size: `h-9 w-9` round avatar; no text label adjacent.
+- Menu: Right-aligned dropdown `w-56` with rounded corners, subtle border, and hover states.
+- Items: “Account Settings”, “Sign out”.
+
+### Tabs (Filters)
+
+- Use compact segment control with `inline-flex rounded-lg border bg-white p-1`.
+- Active tab style: subtle background `bg-neutral-100` in light mode.
+
+### Skeletons
+
+- Use animated placeholders during suspense: `animate-pulse` with theme-aware colors `bg-black/10` or `dark:bg-white/10`.
+
+## Accessibility
+
+- Labels and titles for icon-only buttons via `aria-label`/`title`.
+- Keyboard: All menus focusable; Esc closes; click outside closes.
+- Contrast: Minimum AA; test in both themes.
+
+## Do/Don’t
+
+- Do keep headers light and uncluttered.
+- Do align controls to `h-9` for dense toolbars.
+- Don’t mix multiple button heights in one row.
+- Don’t introduce bright brand colors in core shell; reserve for logos/avatars.
+


### PR DESCRIPTION
## Summary
- skip task list arrow-key shortcuts when event comes from focusable elements or overlays
- add `data-task-list` attribute and adjust tests
- merge latest main and resolve conflicts

## Testing
- `npm run lint`
- `CI=true npm test` *(fails: itemRefs.current[selectedIndex]?.scrollIntoView is not a function)*
- `npm run build` *(terminates after starting build)*

------
https://chatgpt.com/codex/tasks/task_e_68afb2de9e188320879a93cb444f402b