### PR TITLE
style: add high-contrast focus ring

### DIFF
--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -18,19 +18,19 @@ export default function CoursesPage() {
       <h1 className="text-2xl font-semibold">Courses</h1>
       <div className="flex flex-col gap-2 max-w-md">
         <input
-          className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+          className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
           placeholder="Course title"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
         />
         <input
-          className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+          className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
           placeholder="Term (optional)"
           value={term}
           onChange={(e) => setTerm(e.target.value)}
         />
         <input
-          className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+          className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
           placeholder="Color (optional)"
           value={color}
           onChange={(e) => setColor(e.target.value)}
@@ -71,17 +71,17 @@ function CourseItem({ course }: { course: { id: string; title: string; term: str
   return (
     <li className="flex flex-col gap-2 border-b pb-4">
       <input
-        className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+        className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
         value={title}
         onChange={(e) => setTitle(e.target.value)}
       />
       <input
-        className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+        className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
         value={term}
         onChange={(e) => setTerm(e.target.value)}
       />
       <input
-        className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+        className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
         value={color}
         onChange={(e) => setColor(e.target.value)}
       />

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -17,13 +17,13 @@ export default function ProjectsPage() {
       <h1 className="text-2xl font-semibold">Projects</h1>
       <div className="flex flex-col gap-2 max-w-md">
         <input
-          className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+          className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
           placeholder="Project title"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
         />
         <textarea
-          className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+          className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
           placeholder="Description (optional)"
           value={description}
           onChange={(e) => setDescription(e.target.value)}
@@ -62,12 +62,12 @@ function ProjectItem({ project }: { project: { id: string; title: string; descri
   return (
     <li className="flex flex-col gap-2 border-b pb-4">
       <input
-        className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+        className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
         value={title}
         onChange={(e) => setTitle(e.target.value)}
       />
       <textarea
-        className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+        className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
         value={description}
         onChange={(e) => setDescription(e.target.value)}
       />

--- a/src/components/__snapshots__/task-list.test.tsx.snap
+++ b/src/components/__snapshots__/task-list.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`TaskList > applies responsive max height for long lists 1`] = `
           </svg>
           <select
             aria-label="Subject filter"
-            class="appearance-none rounded-full border border-slate-200 bg-slate-100 py-1.5 pl-8 pr-8 text-sm text-slate-800 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-slate-400/50 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200 dark:hover:bg-slate-800"
+            class="appearance-none rounded-full border border-slate-200 bg-slate-100 py-1.5 pl-8 pr-8 text-sm text-slate-800 shadow-sm transition hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200 dark:hover:bg-slate-800"
             title="Filter by subject"
           >
             <option
@@ -131,7 +131,7 @@ exports[`TaskList > applies responsive max height for long lists 1`] = `
           </svg>
           <select
             aria-label="Priority filter"
-            class="appearance-none rounded-full border border-slate-200 bg-slate-100 py-1.5 pl-8 pr-8 text-sm text-slate-800 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-slate-400/50 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200 dark:hover:bg-slate-800"
+            class="appearance-none rounded-full border border-slate-200 bg-slate-100 py-1.5 pl-8 pr-8 text-sm text-slate-800 shadow-sm transition hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200 dark:hover:bg-slate-800"
             title="Filter by priority"
           >
             <option

--- a/src/components/new-task-form.tsx
+++ b/src/components/new-task-form.tsx
@@ -24,7 +24,7 @@ export function NewTaskForm() {
   return (
     <div className="flex items-center gap-2">
       <input
-        className="flex-1 rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+        className="flex-1 rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
         placeholder="Add a task…"
         value={title}
         onChange={(e) => setTitle(e.target.value)}

--- a/src/components/task-filter-tabs.tsx
+++ b/src/components/task-filter-tabs.tsx
@@ -77,7 +77,7 @@ export function TaskFilterTabs({
           <select
             aria-label="Subject filter"
             title="Filter by subject"
-            className="appearance-none rounded-full border border-slate-200 bg-slate-100 py-1.5 pl-8 pr-8 text-sm text-slate-800 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-slate-400/50 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200 dark:hover:bg-slate-800"
+            className="appearance-none rounded-full border border-slate-200 bg-slate-100 py-1.5 pl-8 pr-8 text-sm text-slate-800 shadow-sm transition hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200 dark:hover:bg-slate-800"
             value={subject ?? ''}
             onChange={(e) => onSubjectChange(e.target.value || null)}
           >
@@ -97,7 +97,7 @@ export function TaskFilterTabs({
           <select
             aria-label="Priority filter"
             title="Filter by priority"
-            className="appearance-none rounded-full border border-slate-200 bg-slate-100 py-1.5 pl-8 pr-8 text-sm text-slate-800 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-slate-400/50 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200 dark:hover:bg-slate-800"
+            className="appearance-none rounded-full border border-slate-200 bg-slate-100 py-1.5 pl-8 pr-8 text-sm text-slate-800 shadow-sm transition hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200 dark:hover:bg-slate-800"
             value={priority ?? ''}
             onChange={(e) => onPriorityChange(e.target.value ? (e.target.value as TaskPriority) : null)}
           >
@@ -115,7 +115,7 @@ export function TaskFilterTabs({
           <select
             aria-label="Course filter"
             title="Filter by course"
-            className="appearance-none rounded-full border border-slate-200 bg-slate-100 py-1.5 pl-8 pr-8 text-sm text-slate-800 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-slate-400/50 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200 dark:hover:bg-slate-800"
+            className="appearance-none rounded-full border border-slate-200 bg-slate-100 py-1.5 pl-8 pr-8 text-sm text-slate-800 shadow-sm transition hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200 dark:hover:bg-slate-800"
             value={courseId ?? ''}
             onChange={(e) => onCourseChange(e.target.value || null)}
           >
@@ -135,7 +135,7 @@ export function TaskFilterTabs({
           <select
             aria-label="Project filter"
             title="Filter by project"
-            className="appearance-none rounded-full border border-slate-200 bg-slate-100 py-1.5 pl-8 pr-8 text-sm text-slate-800 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-slate-400/50 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200 dark:hover:bg-slate-800"
+            className="appearance-none rounded-full border border-slate-200 bg-slate-100 py-1.5 pl-8 pr-8 text-sm text-slate-800 shadow-sm transition hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200 dark:hover:bg-slate-800"
             value={projectId ?? ''}
             onChange={(e) => onProjectChange(e.target.value || null)}
           >

--- a/src/components/task-modal.tsx
+++ b/src/components/task-modal.tsx
@@ -192,7 +192,7 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
         <label className="flex flex-col gap-1">
           <span className="text-xs uppercase tracking-wide opacity-60">Title</span>
           <input
-            className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+            className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
             placeholder="Task title"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
@@ -203,7 +203,7 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
           <label className="flex flex-col gap-1">
             <span className="text-xs uppercase tracking-wide opacity-60">Subject</span>
             <input
-              className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+              className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
               placeholder="e.g., Math, CS, English"
               value={subject}
               onChange={(e) => setSubject(e.target.value)}
@@ -230,7 +230,7 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
             </label>
             <input
               type="datetime-local"
-              className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 disabled:opacity-50 dark:border-white/10 dark:focus:ring-white/20"
+              className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 disabled:opacity-50 dark:border-white/10"
               value={due}
               onChange={(e) => {
                 setDue(e.target.value);
@@ -244,7 +244,7 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
           <label className="flex flex-col gap-1">
             <span className="text-xs uppercase tracking-wide opacity-60">Project</span>
             <select
-              className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+              className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
               value={projectId ?? ""}
               onChange={(e) => setProjectId(e.target.value || null)}
             >
@@ -259,7 +259,7 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
           <label className="flex flex-col gap-1">
             <span className="text-xs uppercase tracking-wide opacity-60">Course</span>
             <select
-              className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+              className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
               value={courseId ?? ""}
               onChange={(e) => setCourseId(e.target.value || null)}
             >
@@ -275,7 +275,7 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
         <label className="flex flex-col gap-1">
           <span className="text-xs uppercase tracking-wide opacity-60">Priority</span>
           <select
-            className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+            className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
             value={priority}
             onChange={(e) => setPriority(e.target.value as Task["priority"])}
           >
@@ -289,7 +289,7 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
           <label className="flex flex-col gap-1">
             <span className="text-xs uppercase tracking-wide opacity-60">Recurrence</span>
             <select
-              className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+              className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
               value={recurrenceType}
               onChange={(e) => setRecurrenceType(e.target.value as typeof recurrenceType)}
             >
@@ -305,7 +305,7 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
               <input
                 type="number"
                 min={1}
-                className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+                className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
                 value={recurrenceInterval}
                 onChange={(e) => setRecurrenceInterval(parseInt(e.target.value, 10) || 1)}
               />
@@ -320,7 +320,7 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
               <input
                 type="number"
                 min={1}
-                className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+                className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
                 value={recurrenceCount}
                 onChange={(e) =>
                   setRecurrenceCount(e.target.value ? parseInt(e.target.value, 10) : '')
@@ -331,7 +331,7 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
               <span className="text-xs uppercase tracking-wide opacity-60">End on date</span>
               <input
                 type="date"
-                className="rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+                className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
                 value={recurrenceUntil}
                 onChange={(e) => setRecurrenceUntil(e.target.value)}
               />
@@ -343,7 +343,7 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
           <span className="text-xs uppercase tracking-wide opacity-60">Notes</span>
           <textarea
             rows={4}
-            className="resize-none rounded border border-black/10 bg-transparent px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black/20 dark:border-white/10 dark:focus:ring-white/20"
+            className="resize-none rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
             placeholder="Optional details…"
             value={notes}
             onChange={(e) => setNotes(e.target.value)}

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -20,7 +20,7 @@ export default function ThemeToggle() {
   return (
     <button
       aria-label="Toggle theme"
-      className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-transparent bg-transparent hover:bg-slate-100 dark:hover:bg-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+      className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-transparent bg-transparent hover:bg-slate-100 dark:hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
       onClick={toggle}
       type="button"
     >

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,3 +2,14 @@
 @tailwind components;
 @tailwind utilities;
 html, body, #__next { height: 100%; }
+
+@layer base {
+  a:focus-visible,
+  button:focus-visible,
+  input:focus-visible,
+  textarea:focus-visible,
+  select:focus-visible,
+  [role="button"]:focus-visible {
+    @apply outline-none ring-2 ring-indigo-500 ring-offset-2;
+  }
+}


### PR DESCRIPTION
## Summary
- improve focus accessibility by applying a high-contrast `ring-2 ring-indigo-500 ring-offset-2` to focus-visible states
- update interactive components and inputs to use the new focus ring

## Testing
- `npm run lint`
- `CI=true npm test` *(fails: useDndMonitor must be used within a children of <DndContext>, Error: fail, Error: oops, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad2862f7a88320ab94c260e50ce054