### PR TITLE
feat: add responsive nav bar with active link highlighting

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./../styles/globals.css";
 import React from "react";
 import Providers from "./providers";
+import NavBar from "@/components/nav-bar";
 
 export const metadata = {
   title: "Student Task Scheduler",
@@ -11,6 +12,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" suppressHydrationWarning>
       <body className="min-h-screen bg-neutral-50 text-slate-900 antialiased dark:bg-slate-950 dark:text-slate-100">
+        <NavBar />
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/src/components/nav-bar.test.tsx
+++ b/src/components/nav-bar.test.tsx
@@ -1,0 +1,22 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+import NavBar from './nav-bar';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/calendar',
+}));
+
+expect.extend(matchers);
+
+describe('NavBar', () => {
+  it('highlights the active route', () => {
+    render(<NavBar />);
+    const active = screen.getByRole('link', { name: 'Calendar' });
+    const inactive = screen.getByRole('link', { name: 'Projects' });
+    expect(active).toHaveClass('text-blue-600');
+    expect(inactive).not.toHaveClass('text-blue-600');
+  });
+});

--- a/src/components/nav-bar.tsx
+++ b/src/components/nav-bar.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import React, { useState } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { clsx } from 'clsx';
+
+interface NavItem {
+  href: string;
+  label: string;
+}
+
+const items: NavItem[] = [
+  { href: '/', label: 'Tasks' },
+  { href: '/calendar', label: 'Calendar' },
+  { href: '/projects', label: 'Projects' },
+  { href: '/courses', label: 'Courses' },
+  { href: '/stats', label: 'Stats' },
+  { href: '/settings', label: 'Settings' },
+];
+
+export default function NavBar() {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <nav className="border-b bg-white/80 backdrop-blur dark:bg-slate-950/80">
+      <div className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
+        <div className="flex h-12 items-center justify-between md:h-14">
+          <button
+            aria-label="Toggle navigation"
+            className="p-2 md:hidden"
+            onClick={() => setOpen((v) => !v)}
+          >
+            ☰
+          </button>
+          <div className="hidden gap-4 md:flex">
+            {items.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={clsx(
+                  'px-3 py-2 text-sm border-b-2',
+                  pathname === item.href
+                    ? 'border-blue-600 text-blue-600'
+                    : 'border-transparent text-gray-600 hover:text-gray-800'
+                )}
+              >
+                {item.label}
+              </Link>
+            ))}
+          </div>
+        </div>
+        {open && (
+          <div className="flex flex-col gap-2 pb-2 md:hidden">
+            {items.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={clsx(
+                  'px-3 py-2 text-sm',
+                  pathname === item.href
+                    ? 'text-blue-600'
+                    : 'text-gray-600 hover:text-gray-800'
+                )}
+              >
+                {item.label}
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- add responsive NavBar component with tabs for key pages
- render NavBar in root layout above Providers
- test nav bar highlighting for active route

## Testing
- `npm run lint`
- `npx vitest run src/components/nav-bar.test.tsx`
- `npm run build` *(fails: Type error in src/app/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68afbed76dac83208f280529087c8175