### PR TITLE
feat: add floating task button

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./../styles/globals.css";
 import React from "react";
 import Providers from "./providers";
+import FloatingTaskButton from "@/components/floating-task-button";
 
 export const metadata = {
   title: "Student Task Scheduler",
@@ -12,6 +13,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" suppressHydrationWarning>
       <body className="min-h-screen bg-neutral-50 text-slate-900 antialiased dark:bg-slate-950 dark:text-slate-100">
         <Providers>{children}</Providers>
+        <FloatingTaskButton hiddenPaths={["/settings", "/stats"]} />
       </body>
     </html>
   );

--- a/src/components/floating-task-button.test.tsx
+++ b/src/components/floating-task-button.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+import { FloatingTaskButton } from './floating-task-button';
+
+expect.extend(matchers);
+
+const createMutation = { mutate: vi.fn(), isPending: false, error: undefined as any };
+const updateMutation = { mutate: vi.fn(), isPending: false, error: undefined as any };
+const deleteMutation = { mutate: vi.fn(), isPending: false, error: undefined as any };
+const setStatusMutation = { mutate: vi.fn(), isPending: false, error: undefined as any };
+
+vi.mock('@/server/api/react', () => ({
+  api: {
+    useUtils: () => ({ task: { list: { invalidate: vi.fn() } } }),
+    task: {
+      create: { useMutation: () => createMutation },
+      update: { useMutation: () => updateMutation },
+      delete: { useMutation: () => deleteMutation },
+      setStatus: { useMutation: () => setStatusMutation },
+    },
+    project: { list: { useQuery: () => ({ data: [] }) } },
+    course: { list: { useQuery: () => ({ data: [] }) } },
+  },
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/',
+}));
+
+describe('FloatingTaskButton', () => {
+  it('opens TaskModal when clicked', () => {
+    render(<FloatingTaskButton />);
+    const button = screen.getByRole('button', { name: /add task/i });
+    fireEvent.click(button);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+});

--- a/src/components/floating-task-button.tsx
+++ b/src/components/floating-task-button.tsx
@@ -1,0 +1,33 @@
+"use client";
+import React, { useState } from "react";
+import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { TaskModal } from "@/components/task-modal";
+import { usePathname } from "next/navigation";
+
+interface FloatingTaskButtonProps {
+  hiddenPaths?: string[];
+}
+
+export function FloatingTaskButton({ hiddenPaths = [] }: FloatingTaskButtonProps) {
+  const [open, setOpen] = useState(false);
+  const pathname = usePathname();
+  const shouldHide = hiddenPaths.some((p) => pathname.startsWith(p));
+
+  if (shouldHide) return null;
+
+  return (
+    <>
+      <Button
+        aria-label="Add task"
+        className="fixed bottom-6 right-6 z-50 h-14 w-14 rounded-full p-0 shadow-lg"
+        onClick={() => setOpen(true)}
+      >
+        <Plus className="h-6 w-6" />
+      </Button>
+      <TaskModal open={open} mode="create" onClose={() => setOpen(false)} />
+    </>
+  );
+}
+
+export default FloatingTaskButton;


### PR DESCRIPTION
## Summary
- add FloatingTaskButton component with accessible label that opens TaskModal
- integrate button into root layout and hide on settings/stats routes
- cover button with unit test for modal open behavior

## Testing
- `npm run lint`
- `CI=true npm test src/components/floating-task-button.test.tsx`
- `npm run build` (fails: Argument of type '"archive"' is not assignable to parameter of type '"all" | "overdue" | "today"')


------
https://chatgpt.com/codex/tasks/task_e_68afbef03e388320b9676886310faadc