### PR TITLE
feat: add today control and now indicator

### DIFF
--- a/src/app/calendar/page.test.tsx
+++ b/src/app/calendar/page.test.tsx
@@ -153,4 +153,30 @@ describe('CalendarPage', () => {
     expect(arg.dayWindowStartHour).toBe(6);
     expect(arg.dayWindowEndHour).toBe(20);
   });
+
+  it('resets base date to today when Today is clicked', () => {
+    vi.useFakeTimers();
+    const today = new Date('2024-05-15T12:00:00Z');
+    vi.setSystemTime(today);
+    render(<CalendarPage />);
+    const eventMonday = (() => {
+      const d = new Date(events[0].startAt);
+      d.setHours(0, 0, 0, 0);
+      const diff = (d.getDay() + 6) % 7;
+      d.setDate(d.getDate() - diff);
+      return d;
+    })();
+    const todayMonday = (() => {
+      const d = new Date(today);
+      d.setHours(0, 0, 0, 0);
+      const diff = (d.getDay() + 6) % 7;
+      d.setDate(d.getDate() - diff);
+      return d;
+    })();
+    const fmt = (d: Date) => d.toLocaleDateString(undefined, { weekday: 'short', month: 'numeric', day: 'numeric' });
+    expect(screen.getByText(fmt(eventMonday))).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /today/i }));
+    expect(screen.getByText(fmt(todayMonday))).toBeInTheDocument();
+    vi.useRealTimers();
+  });
 });

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -15,6 +15,7 @@ type Event = RouterOutputs['event']['listRange'][number];
 
 export default function CalendarPage() {
   const [view, setView] = useState<ViewMode>('week');
+  const [baseDate, setBaseDate] = useState<Date>(new Date());
   const utils = api.useUtils();
   const router = useRouter();
   const { data: session } = useSession();
@@ -60,8 +61,12 @@ export default function CalendarPage() {
     return tasksData.filter((t) => !scheduledTaskIds.has(t.id));
   }, [tasksData, eventsData]);
 
-  // Choose a base week to render: prefer the first event's week for stability in tests
-  const baseDate = eventsData?.[0]?.startAt ? new Date(eventsData[0].startAt) : new Date();
+  useEffect(() => {
+    if (eventsData?.[0]?.startAt) {
+      setBaseDate(new Date(eventsData[0].startAt));
+    }
+  }, [eventsData]);
+
   const baseMonday = new Date(baseDate);
   const day = baseMonday.getDay();
   const diff = (day + 6) % 7;
@@ -221,20 +226,31 @@ export default function CalendarPage() {
   return (
     <ErrorBoundary fallback={<main>Failed to load calendar</main>}>
     <main className="grid w-full grid-cols-1 gap-4 md:grid-cols-4">
-      <div className="flex items-center justify-end gap-2 md:col-span-4">
-        <a
-          href="/"
-          className="rounded border px-3 py-1 text-sm hover:bg-black/5 dark:hover:bg-white/5"
-          title="Back to Home"
-          onClick={(e) => { e.preventDefault(); router.push('/'); }}
-        >
-          Home
-        </a>
-        {/* Settings link removed; accessible via AccountMenu */}
-        <Suspense fallback={null}>
-          <AccountMenu />
-        </Suspense>
-      </div>
+      <header className="flex items-center justify-between gap-2 md:col-span-4">
+        <div className="flex items-center gap-2">
+          <a
+            href="/"
+            className="rounded border px-3 py-1 text-sm hover:bg-black/5 dark:hover:bg-white/5"
+            title="Back to Home"
+            onClick={(e) => { e.preventDefault(); router.push('/'); }}
+          >
+            Home
+          </a>
+          <button
+            type="button"
+            className="rounded border px-3 py-1 text-sm hover:bg-black/5 dark:hover:bg-white/5"
+            onClick={() => setBaseDate(new Date())}
+          >
+            Today
+          </button>
+        </div>
+        <div className="flex items-center gap-2">
+          {ViewTabs}
+          <Suspense fallback={null}>
+            <AccountMenu />
+          </Suspense>
+        </div>
+      </header>
       <DndContext
         sensors={sensors}
         collisionDetection={closestCorners}
@@ -296,7 +312,6 @@ export default function CalendarPage() {
         }}
       >
       <div className="w-full space-y-3 md:col-span-1">
-        {ViewTabs}
         <h2 className="font-semibold">Backlog</h2>
         <ul className="space-y-2">
           {backlog.map((t) => (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -50,7 +50,7 @@ export default function HomePage() {
       }
       if ((e.key === "ArrowRight" || e.key === "ArrowLeft") && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
-        const options: Array<"all" | "overdue" | "today"> = ["all", "today", "overdue"];
+        const options: Array<"all" | "overdue" | "today" | "archive"> = ["all", "today", "overdue", "archive"];
         const idx = options.indexOf(filter);
         const nextIndex =
           e.key === "ArrowRight"

--- a/src/components/calendar/CalendarGrid.tsx
+++ b/src/components/calendar/CalendarGrid.tsx
@@ -14,6 +14,11 @@ export function CalendarGrid(props: {
 }) {
   const { view } = props;
   const days = getDays(view, props.startOfWeek);
+  const [now, setNow] = React.useState(new Date());
+  React.useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 60000);
+    return () => clearInterval(id);
+  }, []);
 
   // Special handling for month view - show a simple month grid with events
   if (view === 'month') {
@@ -88,6 +93,11 @@ export function CalendarGrid(props: {
   const endHour = 18;
   const rows = endHour - startHour;
   const rowPx = 48;
+  const showNow =
+    (view === 'day' || view === 'week') &&
+    days.some((d) => d.toDateString() === now.toDateString());
+  const minutesFromStart = now.getHours() * 60 + now.getMinutes() - startHour * 60;
+  const top = (minutesFromStart / 60) * rowPx;
 
   return (
       <div className="border rounded overflow-hidden">
@@ -154,6 +164,13 @@ export function CalendarGrid(props: {
                 />
               );
             })}
+            {showNow && minutesFromStart >= 0 && minutesFromStart <= rows * 60 && (
+              <div
+                data-testid="now-indicator"
+                className="absolute left-20 right-0 h-0.5 bg-red-500"
+                style={{ top }}
+              />
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add Today button on calendar to reset base date
- show live updating current-time line in day and week views
- fix build by including archive filter option

## Testing
- `npm run lint`
- `CI=true npm test src/components/calendar/CalendarGrid.test.tsx src/app/calendar/page.test.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afbf22cfe48320954f394b0a368024