### PR TITLE
feat: validate project fields

### DIFF
--- a/src/app/projects/page.test.tsx
+++ b/src/app/projects/page.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+expect.extend(matchers);
+
+import ProjectsPage from './page';
+
+const createMock = vi.fn();
+const updateMock = vi.fn();
+const listData: { data: Array<{ id: string; title: string; description: string | null }> } = { data: [] };
+
+vi.mock('@/server/api/react', () => ({
+  api: {
+    useUtils: () => ({ project: { list: { invalidate: vi.fn() } } }),
+    project: {
+      list: { useQuery: () => ({ data: listData.data }) },
+      create: { useMutation: () => ({ mutate: createMock }) },
+      update: { useMutation: () => ({ mutate: updateMock }) },
+      delete: { useMutation: () => ({ mutate: vi.fn() }) },
+    },
+  },
+}));
+
+describe('ProjectsPage validation', () => {
+  beforeEach(() => {
+    createMock.mockReset();
+    updateMock.mockReset();
+    listData.data = [];
+  });
+
+  it('shows error when title too long', () => {
+    render(<ProjectsPage />);
+    fireEvent.change(screen.getByPlaceholderText('Project title'), {
+      target: { value: 'a'.repeat(201) },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /add project/i }));
+    expect(
+      screen.getByText(/title must be between 1 and 200 characters/i),
+    ).toBeInTheDocument();
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it('shows error when description too long on update', () => {
+    listData.data = [{ id: '1', title: 'Test', description: 'desc' }];
+    render(<ProjectsPage />);
+    const textarea = screen.getByDisplayValue('desc');
+    fireEvent.change(textarea, { target: { value: 'a'.repeat(1001) } });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    expect(
+      screen.getByText(/description must be at most 1000 characters/i),
+    ).toBeInTheDocument();
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -11,6 +11,8 @@ export default function ProjectsPage() {
   });
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
+  const [titleError, setTitleError] = useState("");
+  const [descriptionError, setDescriptionError] = useState("");
 
   return (
     <main className="space-y-6">
@@ -20,19 +22,39 @@ export default function ProjectsPage() {
           className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
           placeholder="Project title"
           value={title}
-          onChange={(e) => setTitle(e.target.value)}
+          onChange={(e) => {
+            setTitle(e.target.value);
+            if (titleError) setTitleError("");
+          }}
+          aria-invalid={!!titleError}
         />
+        {titleError && <p className="text-sm text-red-500">{titleError}</p>}
         <textarea
           className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
           placeholder="Description (optional)"
           value={description}
-          onChange={(e) => setDescription(e.target.value)}
+          onChange={(e) => {
+            setDescription(e.target.value);
+            if (descriptionError) setDescriptionError("");
+          }}
+          aria-invalid={!!descriptionError}
         />
+        {descriptionError && <p className="text-sm text-red-500">{descriptionError}</p>}
         <Button
           onClick={() => {
             const t = title.trim();
-            if (!t) return;
-            create.mutate({ title: t, description: description.trim() || undefined });
+            const d = description.trim();
+            let hasError = false;
+            if (t.length < 1 || t.length > 200) {
+              setTitleError("Title must be between 1 and 200 characters.");
+              hasError = true;
+            }
+            if (d.length > 1000) {
+              setDescriptionError("Description must be at most 1000 characters.");
+              hasError = true;
+            }
+            if (hasError) return;
+            create.mutate({ title: t, description: d || undefined });
             setTitle("");
             setDescription("");
           }}
@@ -59,23 +81,47 @@ function ProjectItem({ project }: { project: { id: string; title: string; descri
   });
   const [title, setTitle] = useState(project.title);
   const [description, setDescription] = useState(project.description ?? "");
+  const [titleError, setTitleError] = useState("");
+  const [descriptionError, setDescriptionError] = useState("");
   return (
     <li className="flex flex-col gap-2 border-b pb-4">
       <input
         className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
         value={title}
-        onChange={(e) => setTitle(e.target.value)}
+        onChange={(e) => {
+          setTitle(e.target.value);
+          if (titleError) setTitleError("");
+        }}
+        aria-invalid={!!titleError}
       />
+      {titleError && <p className="text-sm text-red-500">{titleError}</p>}
       <textarea
         className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
         value={description}
-        onChange={(e) => setDescription(e.target.value)}
+        onChange={(e) => {
+          setDescription(e.target.value);
+          if (descriptionError) setDescriptionError("");
+        }}
+        aria-invalid={!!descriptionError}
       />
+      {descriptionError && <p className="text-sm text-red-500">{descriptionError}</p>}
       <div className="flex gap-2">
         <Button
-          onClick={() =>
-            update.mutate({ id: project.id, title: title.trim(), description: description.trim() || null })
-          }
+          onClick={() => {
+            const t = title.trim();
+            const d = description.trim();
+            let hasError = false;
+            if (t.length < 1 || t.length > 200) {
+              setTitleError("Title must be between 1 and 200 characters.");
+              hasError = true;
+            }
+            if (d.length > 1000) {
+              setDescriptionError("Description must be at most 1000 characters.");
+              hasError = true;
+            }
+            if (hasError) return;
+            update.mutate({ id: project.id, title: t, description: d || null });
+          }}
         >
           Save
         </Button>


### PR DESCRIPTION
## Summary
- validate project title (1-200) and description (<=1000) before creating or updating
- show inline errors and aria-invalid states
- add tests for project form validation

## Testing
- `npm run lint`
- `CI=true npm test` *(fails: existing failing tests)*
- `node node_modules/vitest/vitest.mjs run src/app/projects/page.test.tsx --testNamePattern="ProjectsPage"`
- `npm run build` *(fails: build did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a87fc6488320b75f9797c689ae52