### PR TITLE
feat: show pending state for project actions

### DIFF
--- a/src/app/projects/page.test.tsx
+++ b/src/app/projects/page.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+expect.extend(matchers);
+import ProjectsPage from './page';
+
+let createIsPending = false;
+let updateIsPending = false;
+let deleteIsPending = false;
+
+vi.mock('@/server/api/react', () => ({
+  api: {
+    useUtils: () => ({ project: { list: { invalidate: vi.fn() } } }),
+    project: {
+      list: {
+        useQuery: () => ({
+          data: [{ id: '1', title: 'Proj', description: null }],
+        }),
+      },
+      create: { useMutation: () => ({ mutate: vi.fn(), isPending: createIsPending }) },
+      update: { useMutation: () => ({ mutate: vi.fn(), isPending: updateIsPending }) },
+      delete: { useMutation: () => ({ mutate: vi.fn(), isPending: deleteIsPending }) },
+    },
+  },
+}));
+
+afterEach(() => {
+  cleanup();
+  createIsPending = false;
+  updateIsPending = false;
+  deleteIsPending = false;
+});
+
+describe('ProjectsPage', () => {
+  it('disables add button when creating', () => {
+    createIsPending = true;
+    render(<ProjectsPage />);
+    const btn = screen.getByRole('button', { name: /saving/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it('disables save button when updating', () => {
+    updateIsPending = true;
+    render(<ProjectsPage />);
+    const btn = screen.getByRole('button', { name: /saving/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it('disables delete button when deleting', () => {
+    deleteIsPending = true;
+    render(<ProjectsPage />);
+    const btn = screen.getByRole('button', { name: /deleting/i });
+    expect(btn).toBeDisabled();
+  });
+});
+

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -29,6 +29,7 @@ export default function ProjectsPage() {
           onChange={(e) => setDescription(e.target.value)}
         />
         <Button
+          disabled={create.isPending}
           onClick={() => {
             const t = title.trim();
             if (!t) return;
@@ -37,7 +38,7 @@ export default function ProjectsPage() {
             setDescription("");
           }}
         >
-          Add Project
+          {create.isPending ? "Saving..." : "Add Project"}
         </Button>
       </div>
       <ul className="space-y-4 max-w-md">
@@ -73,14 +74,19 @@ function ProjectItem({ project }: { project: { id: string; title: string; descri
       />
       <div className="flex gap-2">
         <Button
+          disabled={update.isPending}
           onClick={() =>
             update.mutate({ id: project.id, title: title.trim(), description: description.trim() || null })
           }
         >
-          Save
+          {update.isPending ? "Saving..." : "Save"}
         </Button>
-        <Button variant="danger" onClick={() => del.mutate({ id: project.id })}>
-          Delete
+        <Button
+          variant="danger"
+          disabled={del.isPending}
+          onClick={() => del.mutate({ id: project.id })}
+        >
+          {del.isPending ? "Deleting..." : "Delete"}
         </Button>
       </div>
     </li>


### PR DESCRIPTION
## Summary
- disable project action buttons during pending mutations and show saving/deleting text
- add unit tests covering pending states

## Testing
- `npm run lint`
- `CI=true npm test` *(fails: task-modal and stats tests)*
- `CI=true npx vitest run src/app/projects/page.test.tsx`
- `npm run build` *(hangs: Next.js build did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a886fee883209f49ad28939ce655