### PR TITLE
feat: show saved toast on project mutations

### DIFF
--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -2,12 +2,16 @@
 import React, { useState } from "react";
 import { api } from "@/server/api/react";
 import { Button } from "@/components/ui/button";
+import { toast } from "@/lib/toast";
 
 export default function ProjectsPage() {
   const utils = api.useUtils();
   const { data: projects = [] } = api.project.list.useQuery();
   const create = api.project.create.useMutation({
-    onSuccess: () => utils.project.list.invalidate(),
+    onSuccess: () => {
+      toast.success("Saved!");
+      utils.project.list.invalidate();
+    },
   });
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
@@ -52,10 +56,16 @@ export default function ProjectsPage() {
 function ProjectItem({ project }: { project: { id: string; title: string; description: string | null } }) {
   const utils = api.useUtils();
   const update = api.project.update.useMutation({
-    onSuccess: () => utils.project.list.invalidate(),
+    onSuccess: () => {
+      toast.success("Saved!");
+      utils.project.list.invalidate();
+    },
   });
   const del = api.project.delete.useMutation({
-    onSuccess: () => utils.project.list.invalidate(),
+    onSuccess: () => {
+      toast.success("Saved!");
+      utils.project.list.invalidate();
+    },
   });
   const [title, setTitle] = useState(project.title);
   const [description, setDescription] = useState(project.description ?? "");


### PR DESCRIPTION
## Summary
- show a success toast when creating, updating, or deleting projects

## Testing
- `npm run lint`
- `CI=true npm test` *(fails: UNAUTHORIZED in eventRouter.listRange)*
- `CI=true npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3a88bff6883208d778630633f988b