### PR TITLE
feat: add cancel option for project edits

### DIFF
--- a/src/app/projects/page.test.tsx
+++ b/src/app/projects/page.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+expect.extend(matchers);
+
+import ProjectsPage from './page';
+
+vi.mock('@/server/api/react', () => ({
+  api: {
+    useUtils: () => ({ project: { list: { invalidate: vi.fn() } } }),
+    project: {
+      list: { useQuery: () => ({ data: [{ id: '1', title: 'Initial Title', description: 'Initial Description' }] }) },
+      create: { useMutation: () => ({ mutate: vi.fn() }) },
+      update: { useMutation: () => ({ mutate: vi.fn() }) },
+      delete: { useMutation: () => ({ mutate: vi.fn() }) },
+    },
+  },
+}));
+
+describe('ProjectsPage', () => {
+  it('resets fields to initial values when Cancel is clicked', () => {
+    render(<ProjectsPage />);
+    const inputs = screen.getAllByRole('textbox');
+    const titleInput = inputs[2] as HTMLInputElement;
+    const descInput = inputs[3] as HTMLTextAreaElement;
+
+    fireEvent.change(titleInput, { target: { value: 'Changed Title' } });
+    fireEvent.change(descInput, { target: { value: 'Changed Description' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(titleInput.value).toBe('Initial Title');
+    expect(descInput.value).toBe('Initial Description');
+  });
+});
+

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { api } from "@/server/api/react";
 import { Button } from "@/components/ui/button";
 
@@ -57,8 +57,17 @@ function ProjectItem({ project }: { project: { id: string; title: string; descri
   const del = api.project.delete.useMutation({
     onSuccess: () => utils.project.list.invalidate(),
   });
-  const [title, setTitle] = useState(project.title);
-  const [description, setDescription] = useState(project.description ?? "");
+  const initialTitle = useRef(project.title);
+  const initialDescription = useRef(project.description ?? "");
+  const [title, setTitle] = useState(initialTitle.current);
+  const [description, setDescription] = useState(initialDescription.current);
+
+  useEffect(() => {
+    initialTitle.current = project.title;
+    initialDescription.current = project.description ?? "";
+    setTitle(project.title);
+    setDescription(project.description ?? "");
+  }, [project.title, project.description]);
   return (
     <li className="flex flex-col gap-2 border-b pb-4">
       <input
@@ -78,6 +87,15 @@ function ProjectItem({ project }: { project: { id: string; title: string; descri
           }
         >
           Save
+        </Button>
+        <Button
+          variant="secondary"
+          onClick={() => {
+            setTitle(initialTitle.current);
+            setDescription(initialDescription.current);
+          }}
+        >
+          Cancel
         </Button>
         <Button variant="danger" onClick={() => del.mutate({ id: project.id })}>
           Delete


### PR DESCRIPTION
## Summary
- allow project edits to be cancelled by restoring original values
- cover cancel flow with unit test

## Testing
- `npm run lint`
- `CI=true npm test` *(fails: TaskModal tests and others)*
- `npm run build` *(terminated: build hung)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a88f19288320beab610fcbcb2120