### PR TITLE
feat: show message when no projects

### DIFF
--- a/src/app/projects/page.test.tsx
+++ b/src/app/projects/page.test.tsx
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+expect.extend(matchers);
+
+import ProjectsPage from './page';
+
+vi.mock('@/server/api/react', () => ({
+  api: {
+    useUtils: () => ({ project: { list: { invalidate: () => {} } } }),
+    project: {
+      list: { useQuery: () => ({ data: [] }) },
+      create: { useMutation: () => ({ mutate: () => {} }) },
+    },
+  },
+}));
+
+describe('ProjectsPage', () => {
+  it('shows empty state message when no projects', () => {
+    render(<ProjectsPage />);
+    expect(
+      screen.getByText('No projects yet—add one above.')
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -40,11 +40,15 @@ export default function ProjectsPage() {
           Add Project
         </Button>
       </div>
-      <ul className="space-y-4 max-w-md">
-        {projects.map((p) => (
-          <ProjectItem key={p.id} project={p} />
-        ))}
-      </ul>
+      {projects.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No projects yet—add one above.</p>
+      ) : (
+        <ul className="space-y-4 max-w-md">
+          {projects.map((p) => (
+            <ProjectItem key={p.id} project={p} />
+          ))}
+        </ul>
+      )}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- show a friendly empty state on the projects page
- add unit test for empty projects list

## Testing
- `npm run lint`
- `CI=true npm test src/app/projects/page.test.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3a89189988320aa7eef885246b54d