### PR TITLE
feat: add project sort and filter

### DIFF
--- a/src/app/projects/page.test.tsx
+++ b/src/app/projects/page.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { render, screen, fireEvent, within, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+expect.extend(matchers);
+import ProjectsPage from './page';
+
+const mockProjects = [
+  { id: '1', title: 'Alpha', description: '', createdAt: '2023-01-01T00:00:00Z' },
+  { id: '2', title: 'Beta', description: '', createdAt: '2023-02-01T00:00:00Z' },
+];
+
+vi.mock('@/server/api/react', () => ({
+  api: {
+    useUtils: () => ({ project: { list: { invalidate: vi.fn() } } }),
+    project: {
+      list: { useQuery: () => ({ data: mockProjects }) },
+      create: { useMutation: () => ({ mutate: vi.fn() }) },
+      update: { useMutation: () => ({ mutate: vi.fn() }) },
+      delete: { useMutation: () => ({ mutate: vi.fn() }) },
+    },
+  },
+}));
+
+afterEach(() => cleanup());
+
+describe('ProjectsPage', () => {
+  it('filters and sorts projects', () => {
+    render(<ProjectsPage />);
+    const list = screen.getByRole('list');
+    const titles = within(list)
+      .getAllByRole('textbox')
+      .filter((el) => el.tagName === 'INPUT')
+      .map((i) => (i as HTMLInputElement).value);
+    expect(titles).toEqual(['Beta', 'Alpha']);
+
+    const sortSelect = screen.getByRole('combobox', { name: /sort by/i });
+    fireEvent.change(sortSelect, { target: { value: 'title' } });
+    const titlesSorted = within(list)
+      .getAllByRole('textbox')
+      .filter((el) => el.tagName === 'INPUT')
+      .map((i) => (i as HTMLInputElement).value);
+    expect(titlesSorted).toEqual(['Alpha', 'Beta']);
+
+    const searchInput = screen.getByPlaceholderText('Search projects...');
+    fireEvent.change(searchInput, { target: { value: 'Alpha' } });
+    const filtered = within(list)
+      .getAllByRole('textbox')
+      .filter((el) => el.tagName === 'INPUT')
+      .map((i) => (i as HTMLInputElement).value);
+    expect(filtered).toEqual(['Alpha']);
+  });
+});

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -11,6 +11,18 @@ export default function ProjectsPage() {
   });
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
+  const [search, setSearch] = useState("");
+  const [sort, setSort] = useState<"createdAt" | "title">("createdAt");
+
+  const displayed = [...projects]
+    .filter((p) => p.title.toLowerCase().includes(search.toLowerCase()))
+    .sort((a, b) => {
+      if (sort === "title") return a.title.localeCompare(b.title);
+      return (
+        new Date((b as any).createdAt ?? 0).getTime() -
+        new Date((a as any).createdAt ?? 0).getTime()
+      );
+    });
 
   return (
     <main className="space-y-6">
@@ -40,8 +52,25 @@ export default function ProjectsPage() {
           Add Project
         </Button>
       </div>
+      <div className="flex flex-col gap-2 max-w-md">
+        <input
+          className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
+          placeholder="Search projects..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <select
+          aria-label="Sort by"
+          className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
+          value={sort}
+          onChange={(e) => setSort(e.target.value as "createdAt" | "title")}
+        >
+          <option value="createdAt">Creation date</option>
+          <option value="title">Title</option>
+        </select>
+      </div>
       <ul className="space-y-4 max-w-md">
-        {projects.map((p) => (
+        {displayed.map((p) => (
           <ProjectItem key={p.id} project={p} />
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- add search and sort controls to project list
- filter and sort projects before display
- cover project sorting and filtering with unit test

## Testing
- `npm run lint`
- `CI=true npm test src/app/projects/page.test.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3a89317188320b5c30bce3e963e2f