### PR TITLE
feat: secure course router

### DIFF
--- a/src/server/api/routers/course.test.ts
+++ b/src/server/api/routers/course.test.ts
@@ -1,31 +1,45 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const hoisted = vi.hoisted(() => {
+  const findMany = vi.fn().mockResolvedValue([]);
   const create = vi.fn().mockResolvedValue({});
   const update = vi.fn().mockResolvedValue({});
-  return { create, update };
+  const del = vi.fn().mockResolvedValue({});
+  return { findMany, create, update, delete: del };
 });
 
 vi.mock('@/server/db', () => ({
   db: {
     course: {
-      findMany: vi.fn().mockResolvedValue([]),
+      findMany: hoisted.findMany,
       create: hoisted.create,
       update: hoisted.update,
-      delete: vi.fn().mockResolvedValue({}),
+      delete: hoisted.delete,
     },
   },
 }));
 
 import { courseRouter } from './course';
 
+const ctx = { session: { user: { id: 'user1' } } } as any;
+
+describe('courseRouter.list', () => {
+  beforeEach(() => {
+    hoisted.findMany.mockClear();
+  });
+  it('lists courses for user', async () => {
+    await courseRouter.createCaller(ctx).list();
+    expect(hoisted.findMany).toHaveBeenCalledWith({ where: { userId: 'user1' } });
+  });
+});
+
 describe('courseRouter.create', () => {
   beforeEach(() => {
     hoisted.create.mockClear();
   });
   it('creates course with title and optional fields', async () => {
-    await courseRouter.createCaller({}).create({ title: 'c', term: 'fall', color: 'red' });
-    expect(hoisted.create).toHaveBeenCalledWith({ data: { title: 'c', userId: 'anon', term: 'fall', color: 'red' } });
+    await courseRouter.createCaller(ctx).create({ title: 'c', term: 'fall', color: 'red' });
+    expect(hoisted.create).toHaveBeenCalledWith({ data: { title: 'c', userId: 'user1', term: 'fall', color: 'red' } });
   });
 });
 
@@ -34,7 +48,18 @@ describe('courseRouter.update', () => {
     hoisted.update.mockClear();
   });
   it('updates course fields', async () => {
-    await courseRouter.createCaller({}).update({ id: '1', title: 'nc', term: null, color: null });
-    expect(hoisted.update).toHaveBeenCalledWith({ where: { id: '1' }, data: { title: 'nc', term: null, color: null } });
+    await courseRouter.createCaller(ctx).update({ id: '1', title: 'nc', term: null, color: null });
+    expect(hoisted.update).toHaveBeenCalledWith({ where: { id: '1', userId: 'user1' }, data: { title: 'nc', term: null, color: null } });
   });
 });
+
+describe('courseRouter.delete', () => {
+  beforeEach(() => {
+    hoisted.delete.mockClear();
+  });
+  it('deletes course by id for user', async () => {
+    await courseRouter.createCaller(ctx).delete({ id: '1' });
+    expect(hoisted.delete).toHaveBeenCalledWith({ where: { id: '1', userId: 'user1' } });
+  });
+});
+


### PR DESCRIPTION
## Summary
- require authentication for course router operations and scope queries to the session user
- derive user ID from session instead of accepting it in inputs
- cover course router auth filtering with updated tests

## Testing
- `npm run lint`
- `npx vitest run src/server/api/routers/course.test.ts`
- `npm run build` *(incomplete: build stalled and was aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a8a90c5083209384c91d0b04c29b