### PR TITLE
feat: add color picker for courses

### DIFF
--- a/src/app/courses/page.test.tsx
+++ b/src/app/courses/page.test.tsx
@@ -1,0 +1,31 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+expect.extend(matchers);
+
+import CoursesPage from './page';
+
+vi.mock('@/server/api/react', () => ({
+  api: {
+    useUtils: () => ({ course: { list: { invalidate: vi.fn() } } }),
+    course: {
+      list: { useQuery: () => ({ data: [] }) },
+      create: { useMutation: () => ({ mutate: vi.fn() }) },
+      update: { useMutation: () => ({ mutate: vi.fn() }) },
+      delete: { useMutation: () => ({ mutate: vi.fn() }) },
+    },
+  },
+}));
+
+describe('CoursesPage', () => {
+  it('shows swatch preview when color changes', () => {
+    render(<CoursesPage />);
+    const input = screen.getByLabelText('Course color') as HTMLInputElement;
+    const swatch = screen.getByTestId('color-preview');
+    expect(swatch).toHaveStyle({ backgroundColor: '#000000' });
+    fireEvent.change(input, { target: { value: '#123456' } });
+    expect(swatch).toHaveStyle({ backgroundColor: '#123456' });
+  });
+});

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -29,12 +29,20 @@ export default function CoursesPage() {
           value={term}
           onChange={(e) => setTerm(e.target.value)}
         />
-        <input
-          className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
-          placeholder="Color (optional)"
-          value={color}
-          onChange={(e) => setColor(e.target.value)}
-        />
+        <div className="flex items-center gap-2">
+          <input
+            type="color"
+            aria-label="Course color"
+            className="h-10 w-10 rounded border border-black/10 bg-transparent p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
+            value={color || "#000000"}
+            onChange={(e) => setColor(e.target.value)}
+          />
+          <div
+            data-testid="color-preview"
+            className="h-6 w-6 rounded border border-black/10 dark:border-white/10"
+            style={{ backgroundColor: color || "#000000" }}
+          />
+        </div>
         <Button
           onClick={() => {
             const t = title.trim();
@@ -80,11 +88,19 @@ function CourseItem({ course }: { course: { id: string; title: string; term: str
         value={term}
         onChange={(e) => setTerm(e.target.value)}
       />
-      <input
-        className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
-        value={color}
-        onChange={(e) => setColor(e.target.value)}
-      />
+      <div className="flex items-center gap-2">
+        <input
+          type="color"
+          aria-label="Course color"
+          className="h-10 w-10 rounded border border-black/10 bg-transparent p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
+          value={color || "#000000"}
+          onChange={(e) => setColor(e.target.value)}
+        />
+        <div
+          className="h-6 w-6 rounded border border-black/10 dark:border-white/10"
+          style={{ backgroundColor: color || "#000000" }}
+        />
+      </div>
       <div className="flex gap-2">
         <Button
           onClick={() =>


### PR DESCRIPTION
## Summary
- use color input for course creation and editing
- show color preview swatch tied to input state
- add unit test for color picker

## Testing
- `npm run lint`
- `npm test src/app/courses/page.test.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3a8ae0dc0832080d87ec10ce390ca