### PR TITLE
feat: add course sorting options

### DIFF
--- a/src/app/courses/page.test.tsx
+++ b/src/app/courses/page.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+expect.extend(matchers);
+
+import CoursesPage from './page';
+
+const mockCourses = [
+  { id: '1', title: 'B', term: 'Summer', color: null },
+  { id: '2', title: 'A', term: 'Winter', color: null },
+];
+
+vi.mock('@/server/api/react', () => ({
+  api: {
+    useUtils: () => ({ course: { list: { invalidate: () => {} } } }),
+    course: {
+      list: { useQuery: () => ({ data: mockCourses }) },
+      create: { useMutation: () => ({ mutate: () => {} }) },
+      update: { useMutation: () => ({ mutate: () => {} }) },
+      delete: { useMutation: () => ({ mutate: () => {} }) },
+    },
+  },
+}));
+
+describe('CoursesPage', () => {
+  it('sorts courses by title by default and toggles to term', () => {
+    render(<CoursesPage />);
+    const items = screen.getAllByRole('listitem');
+    expect(within(items[0]).getAllByRole('textbox')[0]).toHaveValue('A');
+    fireEvent.click(screen.getByRole('button', { name: /sort by term/i }));
+    const itemsAfter = screen.getAllByRole('listitem');
+    expect(within(itemsAfter[0]).getAllByRole('textbox')[0]).toHaveValue('B');
+  });
+});
+

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -12,6 +12,16 @@ export default function CoursesPage() {
   const [title, setTitle] = useState("");
   const [term, setTerm] = useState("");
   const [color, setColor] = useState("");
+  const [sortBy, setSortBy] = useState<"title" | "term">("title");
+
+  const sortedCourses = courses
+    .slice()
+    .sort((a, b) =>
+      sortBy === "title"
+        ? a.title.localeCompare(b.title)
+        : (a.term ?? "").localeCompare(b.term ?? "") ||
+          a.title.localeCompare(b.title),
+    );
 
   return (
     <main className="space-y-6">
@@ -48,8 +58,22 @@ export default function CoursesPage() {
           Add Course
         </Button>
       </div>
+      <div className="flex gap-2">
+        <Button
+          variant={sortBy === "title" ? "primary" : "secondary"}
+          onClick={() => setSortBy("title")}
+        >
+          Sort by Title
+        </Button>
+        <Button
+          variant={sortBy === "term" ? "primary" : "secondary"}
+          onClick={() => setSortBy("term")}
+        >
+          Sort by Term
+        </Button>
+      </div>
       <ul className="space-y-4 max-w-md">
-        {courses.map((c) => (
+        {sortedCourses.map((c) => (
           <CourseItem key={c.id} course={c} />
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- allow choosing course order by title or term
- cover course sorting behavior with a test

## Testing
- `npm run lint`
- `CI=true npm test src/app/courses/page.test.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3a8b5946083209f3cb8605768281f