### PR TITLE
feat: add course search filter

### DIFF
--- a/src/app/courses/page.test.tsx
+++ b/src/app/courses/page.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+expect.extend(matchers);
+
+import CoursesPage from './page';
+
+vi.mock('@/server/api/react', () => ({
+  api: {
+    useUtils: () => ({ course: { list: { invalidate: () => {} } } }),
+    course: {
+      list: {
+        useQuery: () => ({
+          data: [
+            { id: '1', title: 'Math', term: null, color: null },
+            { id: '2', title: 'History', term: null, color: null }
+          ]
+        })
+      },
+      create: { useMutation: () => ({ mutate: () => {} }) },
+      update: { useMutation: () => ({ mutate: () => {} }) },
+      delete: { useMutation: () => ({ mutate: () => {} }) }
+    }
+  }
+}));
+
+describe('CoursesPage', () => {
+  it('filters courses by search input', () => {
+    vi.useFakeTimers();
+    render(<CoursesPage />);
+
+    expect(screen.getByDisplayValue('Math')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('History')).toBeInTheDocument();
+
+    const input = screen.getByPlaceholderText('Search courses...');
+    fireEvent.change(input, { target: { value: 'math' } });
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(screen.getByDisplayValue('Math')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('History')).toBeNull();
+    vi.useRealTimers();
+  });
+});

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { api } from "@/server/api/react";
 import { Button } from "@/components/ui/button";
 
@@ -12,6 +12,13 @@ export default function CoursesPage() {
   const [title, setTitle] = useState("");
   const [term, setTerm] = useState("");
   const [color, setColor] = useState("");
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedSearch(search), 300);
+    return () => clearTimeout(t);
+  }, [search]);
 
   return (
     <main className="space-y-6">
@@ -48,11 +55,23 @@ export default function CoursesPage() {
           Add Course
         </Button>
       </div>
-      <ul className="space-y-4 max-w-md">
-        {courses.map((c) => (
-          <CourseItem key={c.id} course={c} />
-        ))}
-      </ul>
+      <div className="max-w-md">
+        <input
+          className="mb-4 w-full rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
+          placeholder="Search courses..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <ul className="space-y-4">
+          {courses
+            .filter((c) =>
+              c.title.toLowerCase().includes(debouncedSearch.toLowerCase())
+            )
+            .map((c) => (
+              <CourseItem key={c.id} course={c} />
+            ))}
+        </ul>
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add debounced search input to filter courses
- test course search functionality

## Testing
- `npm run lint`
- `CI=true npm test src/app/courses/page.test.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3a8b8fec883209d9ecb0ab3533c08