### PR TITLE
fix: remove duplicate account icon on calendar page

### DIFF
--- a/src/app/calendar/page.test.tsx
+++ b/src/app/calendar/page.test.tsx
@@ -77,6 +77,11 @@ describe('CalendarPage', () => {
     expect(link).toHaveAttribute('href', '/');
   });
 
+  it('does not render its own account menu', () => {
+    render(<CalendarPage />);
+    expect(screen.queryByLabelText(/account menu/i)).toBeNull();
+  });
+
   it('shows unscheduled tasks in backlog and scheduled tasks on grid', () => {
     render(<CalendarPage />);
 

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { Suspense, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { DndContext, type DragEndEvent, MouseSensor, TouchSensor, useSensor, useSensors, closestCorners } from '@dnd-kit/core';
 import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
@@ -7,8 +7,6 @@ import { api } from '@/server/api/react';
 import type { RouterOutputs } from '@/server/api/root';
 import { CalendarGrid, DraggableTask } from '@/components/calendar/CalendarGrid';
 import { ErrorBoundary } from '@/components/error-boundary';
-import { AccountMenu } from '@/components/account-menu';
-// Account menu provided globally in nav bar
 
 type ViewMode = 'day' | 'week' | 'month';
 type Task = RouterOutputs['task']['list'][number];
@@ -251,9 +249,6 @@ export default function CalendarPage() {
         </div>
         <div className="flex items-center gap-2">
           {ViewTabs}
-          <Suspense fallback={null}>
-            <AccountMenu />
-          </Suspense>
         </div>
       </header>
       <DndContext


### PR DESCRIPTION
## Summary
- remove local AccountMenu from calendar page header to avoid duplicate account icon
- test that calendar page does not render its own account menu

## Testing
- `npm run lint`
- `CI=true npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4c8d75a208320a3660883fab0998c