### PR TITLE
fix: align backlog panel

### DIFF
--- a/src/app/calendar/page.test.tsx
+++ b/src/app/calendar/page.test.tsx
@@ -93,6 +93,12 @@ describe('CalendarPage', () => {
     expect(main).toHaveClass('md:grid-cols-4');
   });
 
+  it('aligns backlog section to the top', () => {
+    render(<CalendarPage />);
+    const backlogSection = screen.getByRole('heading', { name: /backlog/i }).parentElement;
+    expect(backlogSection).toHaveClass('self-start');
+  });
+
   it('focus mode toggles on with Space on a task', () => {
     render(<CalendarPage />);
     const backlogItem = screen.getByRole('button', { name: /focus Unscheduled task/i });

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -316,7 +316,7 @@ export default function CalendarPage() {
           }
         }}
       >
-      <div className="w-full space-y-3 md:col-span-1">
+      <div className="w-full space-y-3 self-start md:col-span-1">
         <h2 className="font-semibold">Backlog</h2>
         <ul className="space-y-2">
           {backlog.map((t) => (


### PR DESCRIPTION
## Summary
- prevent backlog column from stretching with calendar grid
- add test to ensure backlog stays pinned to top

## Testing
- `npm run lint`
- `npx vitest run src/app/calendar/page.test.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4c9202164832087f351ecdc35aa8d