### PR TITLE
fix: guard google calendar sync consistency

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -147,6 +147,7 @@ model Event {
   startAt  DateTime
   endAt    DateTime
   location String?
+  googleEventId String? @unique
 }
 
 enum ReminderChannel {


### PR DESCRIPTION
## Summary
- avoid orphaned events by inserting into Google Calendar before saving
- track `googleEventId` to deduplicate syncs
- extend router tests around Google syncing

## Testing
- `npx prisma generate`
- `npx prisma db push` *(fails: Environment variable not found: DATABASE_URL)*
- `npm run lint`
- `npx vitest run src/server/api/routers/event.test.ts`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4ce69e3708320aef239083fa2160b