### PR TITLE
feat: add calendar navigation

### DIFF
--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -68,12 +68,20 @@ export default function CalendarPage() {
     }
   }, [eventsData]);
 
-  const baseMonday = new Date(baseDate);
-  const day = baseMonday.getDay();
-  const diff = (day + 6) % 7;
-  baseMonday.setDate(baseMonday.getDate() - diff);
-  // For day view we want to anchor to "today" rather than the week's Monday
-  const todayDate = new Date();
+  const changeDate = React.useCallback((delta: number) => {
+    setBaseDate((prev) => {
+      const d = new Date(prev);
+      if (view === 'day') {
+        d.setDate(d.getDate() + delta);
+      } else if (view === 'week') {
+        d.setDate(d.getDate() + delta * 7);
+      } else {
+        d.setDate(1);
+        d.setMonth(d.getMonth() + delta);
+      }
+      return d;
+    });
+  }, [view]);
 
   const focusStart = api.focus.start.useMutation({
     onSuccess: async () => {
@@ -236,18 +244,36 @@ export default function CalendarPage() {
           >
             Home
           </a>
-          <button
-            type="button"
-            className={`rounded border px-3 py-1 text-sm hover:bg-black/5 dark:hover:bg-white/5 ${
-              baseDate.toDateString() === new Date().toDateString()
-                ? 'bg-blue-600 text-white border-blue-600 dark:bg-blue-500 dark:border-blue-500'
-                : ''
-            }`}
-            onClick={() => setBaseDate(new Date())}
-            aria-current={baseDate.toDateString() === new Date().toDateString() ? 'date' : undefined}
-          >
-            Today
-          </button>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              aria-label="Previous"
+              className="rounded border px-3 py-1 text-sm hover:bg-black/5 dark:hover:bg-white/5"
+              onClick={() => changeDate(-1)}
+            >
+              Prev
+            </button>
+            <button
+              type="button"
+              className={`rounded border px-3 py-1 text-sm hover:bg-black/5 dark:hover:bg-white/5 ${
+                baseDate.toDateString() === new Date().toDateString()
+                  ? 'bg-blue-600 text-white border-blue-600 dark:bg-blue-500 dark:border-blue-500'
+                  : ''
+              }`}
+              onClick={() => setBaseDate(new Date())}
+              aria-current={baseDate.toDateString() === new Date().toDateString() ? 'date' : undefined}
+            >
+              Today
+            </button>
+            <button
+              type="button"
+              aria-label="Next"
+              className="rounded border px-3 py-1 text-sm hover:bg-black/5 dark:hover:bg-white/5"
+              onClick={() => changeDate(1)}
+            >
+              Next
+            </button>
+          </div>
         </div>
         <div className="flex items-center gap-2">
           {ViewTabs}
@@ -357,7 +383,7 @@ export default function CalendarPage() {
         <div data-testid="calendar-grid">
           <CalendarGrid
             view={view}
-            startOfWeek={view === 'day' ? todayDate : baseMonday}
+            startOfWeek={baseDate}
             workStartHour={dayStart}
             workEndHour={dayEnd}
             onDropTask={(taskId, startAt) => {


### PR DESCRIPTION
## Summary
- allow moving between days, weeks, and months via Prev/Next buttons
- reset calendar to current date when selecting Today
- add tests for day, week, and month navigation

## Testing
- `npm run lint`
- `CI=true npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4c94f5ec0832095186b79455a6ed8