### PR TITLE
feat: animate calendar event resizing

### DIFF
--- a/src/components/calendar/CalendarGrid.test.tsx
+++ b/src/components/calendar/CalendarGrid.test.tsx
@@ -142,6 +142,28 @@ describe('CalendarGrid interactions', () => {
     expect(onResizeEvent).toHaveBeenCalledWith('e1', 'end', new Date('2099-01-01T11:00:00.000Z'));
   });
 
+  it('updates event box position while dragging resize handles', () => {
+    const start = '2099-01-01T09:00:00.000Z';
+    const end = '2099-01-01T10:00:00.000Z';
+    render(
+      <CalendarGrid
+        view="day"
+        startOfWeek={new Date('2099-01-01T00:00:00Z')}
+        events={[{ id: 'e1', taskId: 't1', startAt: start, endAt: end, title: 'Study' }]}
+        onDropTask={() => {}}
+      />
+    );
+    const box = screen.getByText('Study').parentElement!.parentElement as HTMLElement;
+    expect(box.style.height).toBe('48px');
+    expect(box.style.top).toBe('432px');
+    act(() => {
+      const setter = transforms.get('event-resize-start-e1');
+      setter?.({ x: 0, y: -24 });
+    });
+    expect(box.style.top).toBe('408px');
+    expect(box.style.height).toBe('72px');
+  });
+
   it('stacks overlapping events in DOM order', () => {
     const events = [
       { id: 'a', taskId: 't1', startAt: '2099-01-01T09:00:00.000Z', endAt: '2099-01-01T10:00:00.000Z', title: 'Event A' },

--- a/src/components/calendar/CalendarGrid.tsx
+++ b/src/components/calendar/CalendarGrid.tsx
@@ -278,9 +278,31 @@ function ResizableEventBox({ id, title, style, pxPerMin, onResizeDelta }: { id: 
   const resEnd = useDraggable({ id: `event-resize-end-${id}` });
   const lastStartY = React.useRef(0);
   const lastEndY = React.useRef(0);
-  const moveStyle: React.CSSProperties = ev.transform ? { transform: `translate3d(${ev.transform.x}px, ${ev.transform.y}px, 0)` } : {};
-  const startStyle: React.CSSProperties = resStart.transform ? { transform: `translate3d(${resStart.transform.x}px, ${resStart.transform.y}px, 0)` } : {};
-  const endStyle: React.CSSProperties = resEnd.transform ? { transform: `translate3d(${resEnd.transform.x}px, ${resEnd.transform.y}px, 0)` } : {};
+  const moveStyle: React.CSSProperties = ev.transform
+    ? { transform: `translate3d(${ev.transform.x}px, ${ev.transform.y}px, 0)` }
+    : {};
+
+  // Track current pixel deltas for live preview
+  const startY = resStart.transform?.y ?? 0;
+  const endY = resEnd.transform?.y ?? 0;
+
+  const baseTop = Number(style.top) || 0;
+  const baseHeight = Number(style.height) || 0;
+  const dynamicStyle: React.CSSProperties = {
+    ...style,
+    top: baseTop + startY,
+    height: Math.max(12, baseHeight + endY - startY),
+  };
+
+  // Keep handles visually attached to edges as box resizes
+  const startStyle: React.CSSProperties = resStart.transform
+    ? { transform: `translate3d(${resStart.transform.x}px, ${resStart.transform.y - startY}px, 0)` }
+    : {};
+  const endStyle: React.CSSProperties = resEnd.transform
+    ? { transform: `translate3d(${resEnd.transform.x}px, ${resEnd.transform.y - endY}px, 0)` }
+    : {};
+
+  const isResizing = resStart.isDragging || resEnd.isDragging || ev.isDragging;
 
   React.useEffect(() => {
     if (resStart.transform) lastStartY.current = resStart.transform.y;
@@ -313,8 +335,8 @@ function ResizableEventBox({ id, title, style, pxPerMin, onResizeDelta }: { id: 
   return (
     <div
       ref={ev.setNodeRef}
-      className="pointer-events-auto select-none rounded border bg-slate-100/90 px-2 py-1 text-xs dark:bg-slate-800/90"
-      style={{ ...style, ...moveStyle }}
+      className={`pointer-events-auto select-none rounded border bg-slate-100/90 px-2 py-1 text-xs dark:bg-slate-800/90 transition-[top,height] duration-150 ease-out ${isResizing ? 'shadow-lg ring-1 ring-blue-400 dark:ring-blue-600' : ''}`}
+      style={{ ...dynamicStyle, ...moveStyle }}
     >
       <div className="flex items-center justify-between cursor-move" {...ev.attributes} {...ev.listeners}>
         <span>{title || 'Event'}</span>
@@ -323,7 +345,7 @@ function ResizableEventBox({ id, title, style, pxPerMin, onResizeDelta }: { id: 
         ref={resStart.setNodeRef}
         {...resStart.attributes}
         {...resStart.listeners}
-        className="absolute left-1/2 top-0 z-10 h-3 w-8 -translate-x-1/2 -translate-y-1/2 cursor-ns-resize rounded bg-slate-400 dark:bg-slate-600"
+        className="absolute left-1/2 top-0 z-10 h-3 w-8 -translate-x-1/2 -translate-y-1/2 cursor-ns-resize rounded bg-slate-400 dark:bg-slate-600 transition-transform duration-150"
         style={startStyle}
         aria-label="resize start"
       />
@@ -331,7 +353,7 @@ function ResizableEventBox({ id, title, style, pxPerMin, onResizeDelta }: { id: 
         ref={resEnd.setNodeRef}
         {...resEnd.attributes}
         {...resEnd.listeners}
-        className="absolute bottom-0 left-1/2 z-10 h-3 w-8 -translate-x-1/2 translate-y-1/2 cursor-ns-resize rounded bg-slate-400 dark:bg-slate-600"
+        className="absolute bottom-0 left-1/2 z-10 h-3 w-8 -translate-x-1/2 translate-y-1/2 cursor-ns-resize rounded bg-slate-400 dark:bg-slate-600 transition-transform duration-150"
         style={endStyle}
         aria-label="resize end"
       />


### PR DESCRIPTION
## Summary
- animate calendar event box while resizing
- polish resize handles with transitions
- test live update of event box during drag

## Testing
- `npm run lint`
- `CI=true npm test src/components/calendar/CalendarGrid.test.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4c9a4668c8320aa1667cf42a73ba7