### PR TITLE
style: add card container to projects page

### DIFF
--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -54,8 +54,9 @@ export default function ProjectsPage() {
     });
 
   return (
-    <main className="space-y-6">
-      <h1 className="text-2xl font-semibold">Projects</h1>
+    <main>
+      <div className="max-w-4xl mx-auto px-4 py-6 space-y-6 rounded-xl border bg-white dark:bg-zinc-900 shadow-sm p-4">
+        <h1 className="text-2xl font-semibold">Projects</h1>
       <form onSubmit={handleSubmit} className="flex flex-col gap-2 max-w-md">
         <label htmlFor="new-project-title" className="sr-only">
           Project title
@@ -117,6 +118,7 @@ export default function ProjectsPage() {
           ))}
         </ul>
       )}
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- wrap projects page content in centered card container with primary card styles

## Testing
- `npm run lint`
- `CI=true npm test src/app/projects/page.test.tsx`
- `npm run build` *(fails: Object literal may only specify known properties, and 'googleEventId' does not exist in type 'Without<EventCreateInput, EventUncheckedCreateInput> & EventUncheckedCreateInput')*


------
https://chatgpt.com/codex/tasks/task_e_68b4f0c04d2883209c3dd037fd76e029