### PR TITLE
feat: add reusable input components

### DIFF
--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 import React, { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { toast } from "@/lib/toast";
 import { api } from "@/server/api/react";
 import { useSession } from "next-auth/react";
@@ -60,9 +62,8 @@ export default function ProjectsPage() {
         <label htmlFor="new-project-title" className="sr-only">
           Project title
         </label>
-        <input
+        <Input
           id="new-project-title"
-          className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
           placeholder="Project title"
           value={title}
           onChange={(e) => {
@@ -75,9 +76,8 @@ export default function ProjectsPage() {
         <label htmlFor="new-project-description" className="sr-only">
           Description (optional)
         </label>
-        <textarea
+        <Textarea
           id="new-project-description"
-          className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
           placeholder="Description (optional)"
           value={description}
           onChange={(e) => {
@@ -92,8 +92,7 @@ export default function ProjectsPage() {
         </Button>
       </form>
       <div className="flex flex-col gap-2 max-w-md">
-        <input
-          className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
+        <Input
           placeholder="Search projects..."
           value={search}
           onChange={(e) => setSearch(e.target.value)}
@@ -155,9 +154,8 @@ function ProjectItem({ project }: { project: { id: string; title: string; descri
       <label htmlFor={`project-${project.id}-title`} className="sr-only">
         Project title
       </label>
-      <input
+      <Input
         id={`project-${project.id}-title`}
-        className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
         value={title}
         onChange={(e) => {
           setTitle(e.target.value);
@@ -169,9 +167,8 @@ function ProjectItem({ project }: { project: { id: string; title: string; descri
       <label htmlFor={`project-${project.id}-description`} className="sr-only">
         Description
       </label>
-      <textarea
+      <Textarea
         id={`project-${project.id}-description`}
-        className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
         value={description}
         onChange={(e) => {
           setDescription(e.target.value);

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { clsx } from "clsx";
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, ...props }, ref) => {
+    const base =
+      "rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10";
+    return <input ref={ref} className={clsx(base, className)} {...props} />;
+  }
+);
+Input.displayName = "Input";
+
+export default Input;

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { clsx } from "clsx";
+
+export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    const base =
+      "rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10";
+    return <textarea ref={ref} className={clsx(base, className)} {...props} />;
+  }
+);
+Textarea.displayName = "Textarea";
+
+export default Textarea;


### PR DESCRIPTION
## Summary
- create reusable `Input` and `Textarea` components with shared styling
- refactor Projects page to use the new components

## Testing
- `npm run lint`
- `CI=true npm test`
- `npm run build` *(fails: Object literal may only specify known properties, and 'googleEventId' does not exist in type)*


------
https://chatgpt.com/codex/tasks/task_e_68b4f0cc3cc883209ba83181382fa06d