### PR TITLE
feat: add project toolbar

### DIFF
--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 import React, { useEffect, useRef, useState } from "react";
+import { useSession } from "next-auth/react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { toast } from "@/lib/toast";
 import { api } from "@/server/api/react";
-import { useSession } from "next-auth/react";
 
 export default function ProjectsPage() {
   const utils = api.useUtils();
@@ -91,16 +92,16 @@ export default function ProjectsPage() {
           {create.isPending ? "Saving..." : "Add Project"}
         </Button>
       </form>
-      <div className="flex flex-col gap-2 max-w-md">
-        <input
-          className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
+      <div className="flex items-center gap-2 max-w-md">
+        <Input
+          className="w-40 md:w-80"
           placeholder="Search projects..."
           value={search}
           onChange={(e) => setSearch(e.target.value)}
         />
         <select
           aria-label="Sort by"
-          className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
+          className="h-9 rounded-md border border-black/10 bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
           value={sort}
           onChange={(e) => setSort(e.target.value as "createdAt" | "title")}
         >

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { clsx } from "clsx";
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, ...props }, ref) => (
+    <input
+      ref={ref}
+      className={clsx(
+        "h-9 w-full rounded-md border border-black/10 bg-transparent px-3 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+Input.displayName = "Input";
+
+export default Input;


### PR DESCRIPTION
## Summary
- add toolbar to project page with search input and sort dropdown
- add shared Input component for consistent styling

## Testing
- `npm run lint`
- `CI=true npm test src/app/projects/page.test.tsx`
- `npm run build` *(fails: Object literal may only specify known properties, and 'googleEventId' does not exist in type 'Without<EventCreateInput, EventUncheckedCreateInput> & EventUncheckedCreateInput'.)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f0d1e2648320b1a2f27045573158