### PR TITLE
feat: display projects in responsive grid

### DIFF
--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -111,11 +111,11 @@ export default function ProjectsPage() {
       {projects.length === 0 ? (
         <p className="text-sm text-muted-foreground">No projects yet—add one above.</p>
       ) : (
-        <ul className="space-y-4 max-w-md">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3" role="list">
           {displayed.map((p) => (
             <ProjectItem key={p.id} project={p} />
           ))}
-        </ul>
+        </div>
       )}
     </main>
   );
@@ -151,7 +151,10 @@ function ProjectItem({ project }: { project: { id: string; title: string; descri
     setDescription(project.description ?? "");
   }, [project.title, project.description]);
   return (
-    <li className="flex flex-col gap-2 border-b pb-4">
+    <div
+      role="listitem"
+      className="flex h-full flex-col gap-2 rounded-xl border shadow-sm p-4"
+    >
       <label htmlFor={`project-${project.id}-title`} className="sr-only">
         Project title
       </label>
@@ -224,6 +227,6 @@ function ProjectItem({ project }: { project: { id: string; title: string; descri
           {del.isPending ? "Deleting..." : "Delete"}
         </Button>
       </div>
-    </li>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- render projects in a responsive grid
- show each project in a card for consistent layout

## Testing
- `npm run lint`
- `CI=true npm test`
- `npm run build` *(fails: Object literal may only specify known properties, and 'googleEventId' does not exist in type 'Without<EventCreateInput, EventUncheckedCreateInput> & EventUncheckedCreateInput')*


------
https://chatgpt.com/codex/tasks/task_e_68b4f0e1dd4c8320add0a75f4692cb0b