### PR TITLE
feat: show project tasks in project view

### DIFF
--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -1,0 +1,42 @@
+"use client";
+import React, { useState } from "react";
+import { TaskList } from "@/components/task-list";
+import { TaskModal } from "@/components/task-modal";
+import { Button } from "@/components/ui/button";
+import { api } from "@/server/api/react";
+
+export default function ProjectDetailPage({ params }: { params: { id: string } }) {
+  const { id } = params;
+  const { data: project } = api.project.byId.useQuery({ id });
+  const [showModal, setShowModal] = useState(false);
+
+  if (!project) return null;
+
+  return (
+    <main className="max-w-4xl mx-auto px-4 py-6 space-y-6">
+      <div className="space-y-1">
+        <h1 className="text-2xl font-semibold">{project.title}</h1>
+        {project.description && (
+          <p className="text-sm text-muted-foreground">{project.description}</p>
+        )}
+      </div>
+      <div className="rounded-xl border bg-white shadow-sm p-4 space-y-4">
+        <TaskList
+          filter="all"
+          subject={null}
+          priority={null}
+          courseId={null}
+          projectId={id}
+          query=""
+        />
+        <Button onClick={() => setShowModal(true)}>+ Add Task</Button>
+      </div>
+      <TaskModal
+        open={showModal}
+        mode="create"
+        onClose={() => setShowModal(false)}
+        initialProjectId={id}
+      />
+    </main>
+  );
+}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -2,6 +2,7 @@
 import React, { useState } from "react";
 import { useSession } from "next-auth/react";
 import { Pencil } from "lucide-react";
+import { useRouter } from "next/navigation";
 
 import { EmptyProjects } from "@/components/empty-projects";
 import { Button } from "@/components/ui/button";
@@ -95,10 +96,12 @@ export default function ProjectsPage() {
 type ProjectTileProps = { project: Project; onEdit: (p: Project) => void };
 
 function ProjectTile({ project, onEdit }: ProjectTileProps) {
+  const router = useRouter();
   return (
     <div
       role="listitem"
-      className="flex h-full flex-col justify-between rounded-xl border shadow-sm p-4"
+      className="flex h-full flex-col justify-between rounded-xl border shadow-sm p-4 cursor-pointer"
+      onClick={() => router.push(`/projects/${project.id}`)}
     >
       <div>
         <h2 className="font-medium">{project.title}</h2>
@@ -111,7 +114,10 @@ function ProjectTile({ project, onEdit }: ProjectTileProps) {
           type="button"
           aria-label="Edit project"
           className="p-1 text-neutral-400 hover:text-neutral-700"
-          onClick={() => onEdit(project)}
+          onClick={(e) => {
+            e.stopPropagation();
+            onEdit(project);
+          }}
         >
           <Pencil className="h-4 w-4" />
         </button>

--- a/src/components/task-modal.test.tsx
+++ b/src/components/task-modal.test.tsx
@@ -85,22 +85,28 @@ describe('TaskModal due date editing', () => {
   });
 });
 
-describe('TaskModal project and course selection', () => {
+  describe('TaskModal project and course selection', () => {
   beforeEach(() => {
     mutateCreate.mockReset();
     createMutation.error = undefined;
   });
-  it('sends selected project and course when creating', () => {
-    render(<TaskModal open mode="create" onClose={() => {}} />);
-    fireEvent.change(screen.getByPlaceholderText('Task title'), { target: { value: 'T' } });
-    fireEvent.change(screen.getByLabelText('Project'), { target: { value: 'p1' } });
-    fireEvent.change(screen.getByLabelText('Course'), { target: { value: 'c1' } });
-    fireEvent.click(screen.getByText('Create'));
-    expect(mutateCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ title: 'T', projectId: 'p1', courseId: 'c1' })
-    );
+    it('sends selected project and course when creating', () => {
+      render(<TaskModal open mode="create" onClose={() => {}} />);
+      fireEvent.change(screen.getByPlaceholderText('Task title'), { target: { value: 'T' } });
+      fireEvent.change(screen.getByLabelText('Project'), { target: { value: 'p1' } });
+      fireEvent.change(screen.getByLabelText('Course'), { target: { value: 'c1' } });
+      fireEvent.click(screen.getByText('Create'));
+      expect(mutateCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'T', projectId: 'p1', courseId: 'c1' })
+      );
+    });
+
+    it('preselects initial project when provided', () => {
+      render(<TaskModal open mode="create" onClose={() => {}} initialProjectId="p1" />);
+      const select = screen.getByLabelText('Project') as HTMLSelectElement;
+      expect(select.value).toBe('p1');
+    });
   });
-});
 
 describe('TaskModal accessibility', () => {
   beforeEach(() => {

--- a/src/components/task-modal.tsx
+++ b/src/components/task-modal.tsx
@@ -19,9 +19,19 @@ interface TaskModalProps {
   initialTitle?: string;
   initialDueAt?: Date | null;
   onDraftDueChange?: (dueAt: Date | null) => void;
+  initialProjectId?: string | null;
 }
 
-export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueAt, onDraftDueChange }: TaskModalProps) {
+export function TaskModal({
+  open,
+  mode,
+  onClose,
+  task,
+  initialTitle,
+  initialDueAt,
+  onDraftDueChange,
+  initialProjectId,
+}: TaskModalProps) {
   const utils = api.useUtils();
   const isEdit = mode === "edit";
   const apiAny = api as any;
@@ -68,7 +78,7 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
       setRecurrenceInterval(1);
       setRecurrenceCount('');
       setRecurrenceUntil('');
-      setProjectId(null);
+      setProjectId(initialProjectId ?? null);
       setCourseId(null);
       if (initialDueAt) {
         setDueEnabled(true);
@@ -78,7 +88,7 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
         setDueEnabled(false);
       }
     }
-  }, [open, isEdit, task, initialTitle, initialDueAt]);
+  }, [open, isEdit, task, initialTitle, initialDueAt, initialProjectId]);
 
   const create = api.task.create.useMutation({
     onSuccess: async () => {

--- a/src/server/api/routers/project.test.ts
+++ b/src/server/api/routers/project.test.ts
@@ -3,13 +3,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const hoisted = vi.hoisted(() => {
   const create = vi.fn().mockResolvedValue({});
   const update = vi.fn().mockResolvedValue({});
-  return { create, update };
+  const findFirst = vi.fn().mockResolvedValue({});
+  return { create, update, findFirst };
 });
 
 vi.mock('@/server/db', () => ({
   db: {
     project: {
       findMany: vi.fn().mockResolvedValue([]),
+      findFirst: hoisted.findFirst,
       create: hoisted.create,
       update: hoisted.update,
       delete: vi.fn().mockResolvedValue({}),
@@ -36,5 +38,15 @@ describe('projectRouter.update', () => {
   it('updates project fields', async () => {
     await projectRouter.createCaller({}).update({ id: '1', title: 'np', description: null });
     expect(hoisted.update).toHaveBeenCalledWith({ where: { id: '1' }, data: { title: 'np', description: null } });
+  });
+});
+
+describe('projectRouter.byId', () => {
+  beforeEach(() => {
+    hoisted.findFirst.mockClear();
+  });
+  it('fetches project for user', async () => {
+    await projectRouter.createCaller({ session: { user: { id: 'u1' } } as any }).byId({ id: 'p1' });
+    expect(hoisted.findFirst).toHaveBeenCalledWith({ where: { id: 'p1', userId: 'u1' } });
   });
 });

--- a/src/server/api/routers/project.ts
+++ b/src/server/api/routers/project.ts
@@ -8,6 +8,12 @@ export const projectRouter = router({
     const userId = ctx.session.user.id;
     return db.project.findMany({ where: { userId } });
   }),
+  byId: protectedProcedure
+    .input(z.object({ id: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      return db.project.findFirst({ where: { id: input.id, userId } });
+    }),
   create: protectedProcedure
     .input(
       z.object({


### PR DESCRIPTION
## Summary
- link project tiles to a detail view
- show project description and tasks on detail view with add task option
- support default project in task modal and project API lookup

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5b8d31cac8320af2434103853bb05