### PR TITLE
refactor: use responsive container on courses page

### DIFF
--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -58,86 +58,88 @@ export default function CoursesPage() {
   };
 
   return (
-    <main className="space-y-6">
-      <h1 className="text-2xl font-semibold">Courses</h1>
-      <form onSubmit={handleSubmit}>
-        <div className="flex flex-col gap-2 max-w-md">
-          <label htmlFor="course-title" className="flex flex-col gap-1">
-            Course title
-            <input
-              id="course-title"
-            className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
-            placeholder="Course title"
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-          />
-          </label>
-          <label htmlFor="course-term" className="flex flex-col gap-1">
-            Term (optional)
-            <input
-              id="course-term"
-            className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
-            placeholder="Term (optional)"
-            value={term}
-            onChange={(e) => setTerm(e.target.value)}
-          />
-          </label>
-          <label htmlFor="course-color" className="flex flex-col gap-1">
-            Color (optional)
-            <div className="flex items-center gap-2">
+    <div className="container mx-auto px-4">
+      <main className="space-y-6">
+        <h1 className="text-2xl font-semibold">Courses</h1>
+        <form onSubmit={handleSubmit}>
+          <div className="flex flex-col gap-2">
+            <label htmlFor="course-title" className="flex flex-col gap-1">
+              Course title
               <input
-                id="course-color"
-                type="color"
-                aria-label="Course color"
-                className="h-10 w-10 rounded border border-black/10 bg-transparent p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
-                value={color || "#000000"}
-                onChange={(e) => setColor(e.target.value)}
+                id="course-title"
+                className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
+                placeholder="Course title"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
               />
-              <div
-                data-testid="color-preview"
-                className="h-6 w-6 rounded border border-black/10 dark:border-white/10"
-                style={{ backgroundColor: color || "#000000" }}
+            </label>
+            <label htmlFor="course-term" className="flex flex-col gap-1">
+              Term (optional)
+              <input
+                id="course-term"
+                className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
+                placeholder="Term (optional)"
+                value={term}
+                onChange={(e) => setTerm(e.target.value)}
               />
-            </div>
-          </label>
-          <Button type="submit" disabled={isAddDisabled}>
-            Add Course
+            </label>
+            <label htmlFor="course-color" className="flex flex-col gap-1">
+              Color (optional)
+              <div className="flex items-center gap-2">
+                <input
+                  id="course-color"
+                  type="color"
+                  aria-label="Course color"
+                  className="h-10 w-10 rounded border border-black/10 bg-transparent p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
+                  value={color || "#000000"}
+                  onChange={(e) => setColor(e.target.value)}
+                />
+                <div
+                  data-testid="color-preview"
+                  className="h-6 w-6 rounded border border-black/10 dark:border-white/10"
+                  style={{ backgroundColor: color || "#000000" }}
+                />
+              </div>
+            </label>
+            <Button type="submit" disabled={isAddDisabled}>
+              Add Course
+            </Button>
+            {createError && <p className="text-red-500">{createError.message}</p>}
+          </div>
+        </form>
+        <div className="flex gap-2">
+          <Button
+            variant={sortBy === "title" ? "primary" : "secondary"}
+            onClick={() => setSortBy("title")}
+          >
+            Sort by Title
           </Button>
-          {createError && <p className="text-red-500">{createError.message}</p>}
+          <Button
+            variant={sortBy === "term" ? "primary" : "secondary"}
+            onClick={() => setSortBy("term")}
+          >
+            Sort by Term
+          </Button>
         </div>
-      </form>
-      <div className="flex gap-2">
-        <Button
-          variant={sortBy === "title" ? "primary" : "secondary"}
-          onClick={() => setSortBy("title")}
-        >
-          Sort by Title
-        </Button>
-        <Button
-          variant={sortBy === "term" ? "primary" : "secondary"}
-          onClick={() => setSortBy("term")}
-        >
-          Sort by Term
-        </Button>
-      </div>
-      <div className="max-w-md">
-        <input
-          className="mb-4 w-full rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
-          placeholder="Search courses..."
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-        />
-        <ul className="space-y-4">
-          {sortedCourses
-            .filter((c) =>
-              c.title.toLowerCase().includes(debouncedSearch.toLowerCase())
-            )
-            .map((c) => (
-              <CourseItem key={c.id} course={c} />
-            ))}
-        </ul>
-      </div>
-    </main>
+        <div>
+          <input
+            className="mb-4 w-full rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
+            placeholder="Search courses..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+          <ul className="space-y-4">
+            {sortedCourses
+              .filter((c) =>
+                c.title.toLowerCase().includes(debouncedSearch.toLowerCase())
+              )
+              .map((c) => (
+                <CourseItem key={c.id} course={c} />
+              ))}
+          </ul>
+        </div>
+      </main>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- wrap courses page content in responsive container
- drop hard-coded width constraints for responsive layout

## Testing
- `npm run lint`
- `npm test src/app/courses/page.test.tsx`
- `CI=true npm run build` *(hangs after "Creating an optimized production build ...")*


------
https://chatgpt.com/codex/tasks/task_e_68b5b9c589748320b635e9c13daa7253