### PR TITLE
feat: show course color before title

### DIFF
--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -182,7 +182,13 @@ function CourseItem({ course }: { course: { id: string; title: string; term: str
   return (
     <li className="flex flex-col gap-2 border-b pb-4">
       <label htmlFor={titleId} className="flex flex-col gap-1">
-        Title
+        <span className="flex items-center gap-2">
+          Title
+          <span
+            className="h-4 w-4 rounded-full"
+            style={{ backgroundColor: color || "#000" }}
+          />
+        </span>
         <input
           id={titleId}
           className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"


### PR DESCRIPTION
## Summary
- show course color badge next to course title in edit list

## Testing
- `npm run lint`
- `CI=true npm test src/app/courses/page.test.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5b9caa9c48320a47f2c442e1d70b0