### PR TITLE
feat: add radix icons to course buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@next-auth/prisma-adapter": "^1.0.7",
         "@prisma/client": "^5.18.0",
+        "@radix-ui/react-icons": "^1.3.2",
         "@tanstack/react-query": "^5.52.0",
         "@tanstack/react-virtual": "^3.13.12",
         "@trpc/client": "11.4.4",
@@ -601,6 +602,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "5.22.0"
+      }
+    },
+    "node_modules/@radix-ui/react-icons": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-icons/-/react-icons-1.3.2.tgz",
+      "integrity": "sha512-fyQIhGDhzfc9pK2kH6Pl9c4BDJGfMkPqkyIgYDthyNYoNg3wVhoJMMh19WS4Up/1KMPFVpNsT2q3WmXn2N1m6g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@next-auth/prisma-adapter": "^1.0.7",
     "@prisma/client": "^5.18.0",
+    "@radix-ui/react-icons": "^1.3.2",
     "@tanstack/react-query": "^5.52.0",
     "@tanstack/react-virtual": "^3.13.12",
     "@trpc/client": "11.4.4",
@@ -47,7 +48,6 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.46.0",
-    "rollup": "^4.50.0",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",
     "@types/bcryptjs": "^2.4.6",
@@ -63,6 +63,7 @@
     "nodemon": "^3.1.7",
     "postcss": "^8.4.41",
     "prisma": "^5.18.0",
+    "rollup": "^4.50.0",
     "tailwindcss": "^3.4.10",
     "timezone-mock": "^1.3.6",
     "typescript": "5.7.2",

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { api } from "@/server/api/react";
 import { toast } from "@/lib/toast";
+import { TrashIcon, CheckIcon, CaretSortIcon } from "@radix-ui/react-icons";
 
 export default function CoursesPage() {
   const utils = api.useUtils();
@@ -101,6 +102,7 @@ export default function CoursesPage() {
             </div>
           </label>
           <Button type="submit" disabled={isAddDisabled}>
+            <CheckIcon className="mr-1" />
             Add Course
           </Button>
           {createError && <p className="text-red-500">{createError.message}</p>}
@@ -111,12 +113,14 @@ export default function CoursesPage() {
           variant={sortBy === "title" ? "primary" : "secondary"}
           onClick={() => setSortBy("title")}
         >
+          <CaretSortIcon className="mr-1" />
           Sort by Title
         </Button>
         <Button
           variant={sortBy === "term" ? "primary" : "secondary"}
           onClick={() => setSortBy("term")}
         >
+          <CaretSortIcon className="mr-1" />
           Sort by Term
         </Button>
       </div>
@@ -228,6 +232,7 @@ function CourseItem({ course }: { course: { id: string; title: string; term: str
             })
           }
         >
+          <CheckIcon className="mr-1" />
           Save
         </Button>
         <Button
@@ -239,6 +244,7 @@ function CourseItem({ course }: { course: { id: string; title: string; term: str
             }
           }}
         >
+          <TrashIcon className="mr-1" />
           Delete
         </Button>
       </div>


### PR DESCRIPTION
## Summary
- install `@radix-ui/react-icons`
- prepend Radix icons to course management buttons

## Testing
- `npm run lint`
- `CI=true npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5b9ce87d08320a808eaaa48f5f95e