### PR TITLE
feat: add course skeleton for loading state

### DIFF
--- a/src/app/courses/page.test.tsx
+++ b/src/app/courses/page.test.tsx
@@ -35,7 +35,8 @@ describe('CoursesPage', () => {
     listMock.mockReturnValue({ data: [], isLoading: true, error: undefined });
     createMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
     render(<CoursesPage />);
-    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+    const list = screen.getByLabelText('Loading courses');
+    expect(within(list).getAllByRole('listitem')).toHaveLength(4);
   });
 
   it('shows error message', () => {

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
+import { CourseSkeleton } from "@/components/CourseSkeleton";
 import { api } from "@/server/api/react";
 import { toast } from "@/lib/toast";
 
@@ -35,7 +36,17 @@ export default function CoursesPage() {
     return () => clearTimeout(t);
   }, [search]);
 
-  if (isLoading) return <p>Loading...</p>;
+  if (isLoading)
+    return (
+      <ul aria-label="Loading courses" className="space-y-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <CourseSkeleton
+            // eslint-disable-next-line react/no-array-index-key
+            key={i}
+          />
+        ))}
+      </ul>
+    );
   if (error) return <p className="text-red-500">{error.message}</p>;
 
   const sortedCourses = courses

--- a/src/components/CourseSkeleton.tsx
+++ b/src/components/CourseSkeleton.tsx
@@ -1,0 +1,12 @@
+'use client';
+import React from 'react';
+
+export function CourseSkeleton() {
+  return (
+    <li className="flex flex-col gap-2 rounded-md border p-4 animate-pulse">
+      <div className="h-5 w-1/3 rounded bg-black/10 dark:bg-white/10" />
+      <div className="h-4 w-1/4 rounded bg-black/10 dark:bg-white/10" />
+    </li>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add CourseSkeleton component
- render skeletons during courses page loading

## Testing
- `npm run lint`
- `CI=true npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5b9da82bc8320b81992a3d41043a9