### PR TITLE
feat: add sort direction toggle

### DIFF
--- a/src/app/courses/page.test.tsx
+++ b/src/app/courses/page.test.tsx
@@ -98,6 +98,26 @@ describe('CoursesPage', () => {
     expect(within(itemsAfter[0]).getAllByRole('textbox')[0]).toHaveValue('B');
   });
 
+  it('toggles sort direction', () => {
+    const mockCourses = [
+      { id: '1', title: 'A', term: 'Fall', color: null },
+      { id: '2', title: 'B', term: 'Spring', color: null },
+    ];
+    listMock.mockReturnValue({ data: mockCourses, isLoading: false, error: undefined });
+    createMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
+    updateMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
+    deleteMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
+
+    render(<CoursesPage />);
+    const items = screen.getAllByRole('listitem');
+    expect(within(items[0]).getAllByRole('textbox')[0]).toHaveValue('A');
+    fireEvent.click(
+      screen.getByRole('button', { name: /toggle sort direction/i }),
+    );
+    const itemsAfter = screen.getAllByRole('listitem');
+    expect(within(itemsAfter[0]).getAllByRole('textbox')[0]).toHaveValue('B');
+  });
+
   it('filters courses by search input', () => {
     vi.useFakeTimers();
     listMock.mockReturnValue({

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { useState, useEffect } from "react";
+import { ArrowUpDown as ArrowUpDownIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { api } from "@/server/api/react";
 import { toast } from "@/lib/toast";
@@ -26,6 +27,7 @@ export default function CoursesPage() {
   const [term, setTerm] = useState("");
   const [color, setColor] = useState("");
   const [sortBy, setSortBy] = useState<"title" | "term">("title");
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const isAddDisabled = isCreating || title.trim() === "";
@@ -38,14 +40,13 @@ export default function CoursesPage() {
   if (isLoading) return <p>Loading...</p>;
   if (error) return <p className="text-red-500">{error.message}</p>;
 
-  const sortedCourses = courses
-    .slice()
-    .sort((a, b) =>
-      sortBy === "title"
-        ? a.title.localeCompare(b.title)
-        : (a.term ?? "").localeCompare(b.term ?? "") ||
-          a.title.localeCompare(b.title),
-    );
+  const sortedCourses = [...courses].sort((a, b) =>
+    sortBy === "title"
+      ? a.title.localeCompare(b.title)
+      : (a.term ?? "").localeCompare(b.term ?? "") ||
+        a.title.localeCompare(b.title),
+  );
+  if (sortDir === "desc") sortedCourses.reverse();
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -118,6 +119,13 @@ export default function CoursesPage() {
           onClick={() => setSortBy("term")}
         >
           Sort by Term
+        </Button>
+        <Button
+          variant="tertiary"
+          onClick={() => setSortDir(sortDir === "asc" ? "desc" : "asc")}
+          aria-label="Toggle sort direction"
+        >
+          <ArrowUpDownIcon className="h-4 w-4" />
         </Button>
       </div>
       <div className="max-w-md">


### PR DESCRIPTION
## Summary
- add sort direction state for courses and reverse on descending
- expose toggle button with ArrowUpDownIcon
- test sorting direction

## Testing
- `npm run lint -- --file src/app/courses/page.tsx --file src/app/courses/page.test.tsx`
- `CI=true npm test src/app/courses/page.test.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5b9f6bf3c8320b27c555c0130b5e1