### PR TITLE
feat: add pagination to courses

### DIFF
--- a/src/app/courses/page.test.tsx
+++ b/src/app/courses/page.test.tsx
@@ -45,13 +45,13 @@ describe('CoursesPage', () => {
     expect(screen.getByText('Failed')).toBeInTheDocument();
   });
 
-  it('disables add button and shows create error', () => {
-    listMock.mockReturnValue({ data: [], isLoading: false, error: undefined });
-    createMock.mockReturnValue({ mutate: vi.fn(), isPending: true, error: { message: 'Create failed' } });
-    render(<CoursesPage />);
-    expect(screen.getByRole('button', { name: /add course/i })).toBeDisabled();
-    expect(screen.getByText('Create failed')).toBeInTheDocument();
-  });
+    it('disables add button and shows create error', () => {
+      listMock.mockReturnValue({ data: [], isLoading: false, error: undefined });
+      createMock.mockReturnValue({ mutate: vi.fn(), isPending: true, error: { message: 'Create failed' } });
+      render(<CoursesPage />);
+      expect(screen.getByRole('button', { name: /add course/i })).toBeDisabled();
+      expect(screen.getByText('Create failed')).toBeInTheDocument();
+    });
 
   it('disables save and delete buttons and shows errors', () => {
     listMock.mockReturnValue({
@@ -127,4 +127,23 @@ describe('CoursesPage', () => {
     expect(screen.queryByDisplayValue('History')).toBeNull();
     vi.useRealTimers();
   });
+
+    it('fetches different pages when navigating', () => {
+      const mockCourses = Array.from({ length: 10 }, (_, i) => ({
+        id: String(i),
+        title: `C${i}`,
+        term: null,
+        color: null,
+      }));
+      listMock.mockReturnValue({ data: mockCourses, isLoading: false, error: undefined });
+      createMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
+      updateMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
+      deleteMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
+      render(<CoursesPage />);
+      expect(listMock).toHaveBeenLastCalledWith({ page: 1, limit: 10 });
+      act(() => {
+        fireEvent.click(screen.getByRole('button', { name: /next/i }));
+      });
+      expect(listMock).toHaveBeenLastCalledWith({ page: 2, limit: 10 });
+    });
 });

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -6,11 +6,13 @@ import { toast } from "@/lib/toast";
 
 export default function CoursesPage() {
   const utils = api.useUtils();
+  const [page, setPage] = useState(1);
+  const limit = 10;
   const {
     data: courses = [],
     isLoading,
     error,
-  } = api.course.list.useQuery();
+  } = api.course.list.useQuery({ page, limit });
   const {
     mutate: createCourse,
     isPending: isCreating,
@@ -127,19 +129,30 @@ export default function CoursesPage() {
           value={search}
           onChange={(e) => setSearch(e.target.value)}
         />
-        <ul className="space-y-4">
-          {sortedCourses
-            .filter((c) =>
-              c.title.toLowerCase().includes(debouncedSearch.toLowerCase())
-            )
-            .map((c) => (
-              <CourseItem key={c.id} course={c} />
-            ))}
-        </ul>
-      </div>
-    </main>
-  );
-}
+          <ul className="space-y-4">
+            {sortedCourses
+              .filter((c) =>
+                c.title.toLowerCase().includes(debouncedSearch.toLowerCase())
+              )
+              .map((c) => (
+                <CourseItem key={c.id} course={c} />
+              ))}
+          </ul>
+          <div className="mt-4 flex gap-2">
+            <Button onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page === 1}>
+              Previous
+            </Button>
+            <Button
+              onClick={() => setPage((p) => p + 1)}
+              disabled={courses.length < limit}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      </main>
+    );
+  }
 
 function CourseItem({ course }: { course: { id: string; title: string; term: string | null; color: string | null } }) {
   const utils = api.useUtils();

--- a/src/components/task-filter-tabs.tsx
+++ b/src/components/task-filter-tabs.tsx
@@ -43,7 +43,7 @@ export function TaskFilterTabs({
     { filter: 'all' },
     { enabled: !!session }
   );
-  const { data: courses = [] } = api.course.list.useQuery();
+  const { data: courses = [] } = api.course.list.useQuery({ page: 1, limit: 100 });
   const { data: projects = [] } = api.project.list.useQuery();
   const subjects = React.useMemo(() => {
     const set = new Set<string>();

--- a/src/components/task-modal.tsx
+++ b/src/components/task-modal.tsx
@@ -37,7 +37,7 @@ export function TaskModal({ open, mode, onClose, task, initialTitle, initialDueA
   const [recurrenceCount, setRecurrenceCount] = useState<number | ''>('');
   const [recurrenceUntil, setRecurrenceUntil] = useState<string>('');
   const { data: projects = [] } = api.project.list.useQuery();
-  const { data: courses = [] } = api.course.list.useQuery();
+  const { data: courses = [] } = api.course.list.useQuery({ page: 1, limit: 100 });
   const [projectId, setProjectId] = useState<string | null>(null);
   const [courseId, setCourseId] = useState<string | null>(null);
 

--- a/src/server/api/routers/course.test.ts
+++ b/src/server/api/routers/course.test.ts
@@ -27,9 +27,9 @@ describe('courseRouter.list', () => {
   beforeEach(() => {
     hoisted.findMany.mockClear();
   });
-  it('lists courses for user', async () => {
-    await courseRouter.createCaller(ctx).list();
-    expect(hoisted.findMany).toHaveBeenCalledWith({ where: { userId: 'user1' } });
+  it('lists courses for user with pagination', async () => {
+    await courseRouter.createCaller(ctx).list({ page: 2, limit: 5 });
+    expect(hoisted.findMany).toHaveBeenCalledWith({ where: { userId: 'user1' }, skip: 5, take: 5 });
   });
 });
 

--- a/src/server/api/routers/course.ts
+++ b/src/server/api/routers/course.ts
@@ -3,10 +3,22 @@ import { protectedProcedure, router } from '../trpc';
 import { db } from '@/server/db';
 
 export const courseRouter = router({
-  list: protectedProcedure.query(async ({ ctx }) => {
-    const userId = ctx.session.user.id;
-    return db.course.findMany({ where: { userId } });
-  }),
+  list: protectedProcedure
+    .input(
+      z.object({
+        page: z.number().int().min(1).default(1),
+        limit: z.number().int().min(1).max(100).default(10),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      const { page, limit } = input;
+      return db.course.findMany({
+        where: { userId },
+        skip: (page - 1) * limit,
+        take: limit,
+      });
+    }),
   create: protectedProcedure
     .input(
       z.object({


### PR DESCRIPTION
## Summary
- add page/limit inputs to course list API
- paginate courses page with next/previous controls
- update task components to use paginated course API

## Testing
- `npm test src/server/api/routers/course.test.ts src/app/courses/page.test.tsx`
- `npm test src/components/task-filter-tabs.test.tsx src/components/task-modal.test.tsx`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5ba01a15c8320aad34928b04e82cf