### PR TITLE
feat: warn about pending course edits

### DIFF
--- a/src/app/courses/page.test.tsx
+++ b/src/app/courses/page.test.tsx
@@ -127,4 +127,27 @@ describe('CoursesPage', () => {
     expect(screen.queryByDisplayValue('History')).toBeNull();
     vi.useRealTimers();
   });
+
+  it('prompts before unload if there are pending changes', () => {
+    listMock.mockReturnValue({
+      data: [{ id: '1', title: 'Course', term: null, color: null }],
+      isLoading: false,
+      error: undefined,
+    });
+    createMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
+    updateMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
+    deleteMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
+
+    render(<CoursesPage />);
+
+    const noChangeEvent = new Event('beforeunload', { cancelable: true });
+    window.dispatchEvent(noChangeEvent);
+    expect(noChangeEvent.defaultPrevented).toBe(false);
+
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'New Title' } });
+
+    const event = new Event('beforeunload', { cancelable: true });
+    window.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- track pending changes per course item and prompt before leaving page if any exist
- add tests to ensure beforeunload triggers when unsaved changes present

## Testing
- `npm run lint`
- `CI=true npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5ba07895883208c05f3718cd3d14d