### PR TITLE
feat: use color dropdown for courses

### DIFF
--- a/src/app/courses/page.test.tsx
+++ b/src/app/courses/page.test.tsx
@@ -73,11 +73,11 @@ describe('CoursesPage', () => {
     listMock.mockReturnValue({ data: [], isLoading: false, error: undefined });
     createMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
     render(<CoursesPage />);
-    const input = screen.getByLabelText('Course color') as HTMLInputElement;
+    const select = screen.getByLabelText('Course color') as HTMLSelectElement;
     const swatch = screen.getByTestId('color-preview');
     expect(swatch).toHaveStyle({ backgroundColor: '#000000' });
-    fireEvent.change(input, { target: { value: '#123456' } });
-    expect(swatch).toHaveStyle({ backgroundColor: '#123456' });
+    fireEvent.change(select, { target: { value: '#FF0000' } });
+    expect(swatch).toHaveStyle({ backgroundColor: '#FF0000' });
   });
 
   it('sorts courses by title by default and toggles to term', () => {

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -4,6 +4,16 @@ import { Button } from "@/components/ui/button";
 import { api } from "@/server/api/react";
 import { toast } from "@/lib/toast";
 
+const COLOR_OPTIONS = [
+  "#000000",
+  "#FF0000",
+  "#00FF00",
+  "#0000FF",
+  "#FFFF00",
+  "#FF00FF",
+  "#00FFFF",
+];
+
 export default function CoursesPage() {
   const utils = api.useUtils();
   const {
@@ -85,14 +95,20 @@ export default function CoursesPage() {
           <label htmlFor="course-color" className="flex flex-col gap-1">
             Color (optional)
             <div className="flex items-center gap-2">
-              <input
+              <select
                 id="course-color"
-                type="color"
                 aria-label="Course color"
-                className="h-10 w-10 rounded border border-black/10 bg-transparent p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
-                value={color || "#000000"}
+                className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
+                value={color}
                 onChange={(e) => setColor(e.target.value)}
-              />
+              >
+                <option value="">Select color</option>
+                {COLOR_OPTIONS.map((c) => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+              </select>
               <div
                 data-testid="color-preview"
                 className="h-6 w-6 rounded border border-black/10 dark:border-white/10"
@@ -202,14 +218,20 @@ function CourseItem({ course }: { course: { id: string; title: string; term: str
       <label htmlFor={colorId} className="flex flex-col gap-1">
         Color
         <div className="flex items-center gap-2">
-          <input
+          <select
             id={colorId}
-            type="color"
             aria-label="Course color"
-            className="h-10 w-10 rounded border border-black/10 bg-transparent p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
-            value={color || "#000000"}
+            className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
+            value={color}
             onChange={(e) => setColor(e.target.value)}
-          />
+          >
+            <option value="">Select color</option>
+            {COLOR_OPTIONS.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
           <div
             className="h-6 w-6 rounded border border-black/10 dark:border-white/10"
             style={{ backgroundColor: color || "#000000" }}


### PR DESCRIPTION
## Summary
- replace color picker with dropdown of predefined hex colors on courses page
- show selected color swatch beside dropdown for preview
- update tests for new color selector

## Testing
- `npm run lint`
- `CI=true npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5ba0a65ec8320b792f8bd8111ab6b