### PR TITLE
feat: allow course search by term and color

### DIFF
--- a/src/app/courses/page.test.tsx
+++ b/src/app/courses/page.test.tsx
@@ -98,12 +98,12 @@ describe('CoursesPage', () => {
     expect(within(itemsAfter[0]).getAllByRole('textbox')[0]).toHaveValue('B');
   });
 
-  it('filters courses by search input', () => {
+  it('filters courses by title, term, and color', () => {
     vi.useFakeTimers();
     listMock.mockReturnValue({
       data: [
-        { id: '1', title: 'Math', term: null, color: null },
-        { id: '2', title: 'History', term: null, color: null },
+        { id: '1', title: 'Math', term: 'Fall', color: '#ABCDEF' },
+        { id: '2', title: 'History', term: 'Spring', color: '#123456' },
       ],
       isLoading: false,
       error: undefined,
@@ -114,17 +114,32 @@ describe('CoursesPage', () => {
 
     render(<CoursesPage />);
 
-    expect(screen.getByDisplayValue('Math')).toBeInTheDocument();
-    expect(screen.getByDisplayValue('History')).toBeInTheDocument();
-
     const input = screen.getByPlaceholderText('Search courses...');
+
+    // filter by title (case insensitive)
     fireEvent.change(input, { target: { value: 'math' } });
     act(() => {
       vi.advanceTimersByTime(400);
     });
-
     expect(screen.getByDisplayValue('Math')).toBeInTheDocument();
     expect(screen.queryByDisplayValue('History')).toBeNull();
+
+    // filter by term
+    fireEvent.change(input, { target: { value: 'SPRING' } });
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    expect(screen.getByDisplayValue('History')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('Math')).toBeNull();
+
+    // filter by color
+    fireEvent.change(input, { target: { value: '#abcdef' } });
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    expect(screen.getByDisplayValue('Math')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('History')).toBeNull();
+
     vi.useRealTimers();
   });
 });

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -57,6 +57,8 @@ export default function CoursesPage() {
     setColor("");
   };
 
+  const query = debouncedSearch.toLowerCase();
+
   return (
     <main className="space-y-6">
       <h1 className="text-2xl font-semibold">Courses</h1>
@@ -129,9 +131,16 @@ export default function CoursesPage() {
         />
         <ul className="space-y-4">
           {sortedCourses
-            .filter((c) =>
-              c.title.toLowerCase().includes(debouncedSearch.toLowerCase())
-            )
+            .filter((c) => {
+              const title = c.title.toLowerCase();
+              const term = c.term?.toLowerCase() ?? "";
+              const color = c.color?.toLowerCase() ?? "";
+              return (
+                title.includes(query) ||
+                term.includes(query) ||
+                color.includes(query)
+              );
+            })
             .map((c) => (
               <CourseItem key={c.id} course={c} />
             ))}


### PR DESCRIPTION
## Summary
- extend course search to match term and color fields case-insensitively
- test filtering by title, term, and color

## Testing
- `npm run lint`
- `CI=true npm test src/app/courses/page.test.tsx`
- `npm run build` *(fails: process did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ba0d107083208136f9f279edba67