### PR TITLE
fix: only apply parent filter when supplied

### DIFF
--- a/src/server/api/routers/task.test.ts
+++ b/src/server/api/routers/task.test.ts
@@ -70,35 +70,35 @@ describe('taskRouter.list ordering', () => {
       { dueAt: { sort: 'asc', nulls: 'last' } },
       { createdAt: 'desc' },
     ]);
-    expect(arg.where).toEqual({ userId: 'user1', parentId: null });
+    expect(arg.where).toEqual({ userId: 'user1' });
   });
 
   it('filters by subject when provided', async () => {
     await taskRouter.createCaller(ctx).list({ filter: 'all', subject: 'math' });
     expect(hoisted.findMany).toHaveBeenCalledTimes(1);
     const arg = hoisted.findMany.mock.calls[0][0];
-    expect(arg.where).toEqual({ userId: 'user1', parentId: null, subject: 'math' });
+    expect(arg.where).toEqual({ userId: 'user1', subject: 'math' });
   });
 
   it('filters by priority when provided', async () => {
     await taskRouter.createCaller(ctx).list({ filter: 'all', priority: TaskPriority.HIGH });
     expect(hoisted.findMany).toHaveBeenCalledTimes(1);
     const arg = hoisted.findMany.mock.calls[0][0];
-    expect(arg.where).toEqual({ userId: 'user1', parentId: null, priority: TaskPriority.HIGH });
+    expect(arg.where).toEqual({ userId: 'user1', priority: TaskPriority.HIGH });
   });
 
   it('filters by courseId when provided', async () => {
     await taskRouter.createCaller(ctx).list({ filter: 'all', courseId: 'c1' });
     expect(hoisted.findMany).toHaveBeenCalledTimes(1);
     const arg = hoisted.findMany.mock.calls[0][0];
-    expect(arg.where).toEqual({ userId: 'user1', parentId: null, courseId: 'c1' });
+    expect(arg.where).toEqual({ userId: 'user1', courseId: 'c1' });
   });
 
   it('filters by projectId when provided', async () => {
     await taskRouter.createCaller(ctx).list({ filter: 'all', projectId: 'p1' });
     expect(hoisted.findMany).toHaveBeenCalledTimes(1);
     const arg = hoisted.findMany.mock.calls[0][0];
-    expect(arg.where).toEqual({ userId: 'user1', parentId: null, projectId: 'p1' });
+    expect(arg.where).toEqual({ userId: 'user1', projectId: 'p1' });
   });
 
   it('filters by parentId when provided', async () => {
@@ -122,7 +122,7 @@ describe('taskRouter.list ordering', () => {
     endTz.setHours(23, 59, 59, 999);
     const startUtc = new Date(startTz.toLocaleString('en-US', { timeZone: 'UTC' }));
     const endUtc = new Date(endTz.toLocaleString('en-US', { timeZone: 'UTC' }));
-    expect(arg.where).toEqual({ userId: 'user1', parentId: null, dueAt: { gte: startUtc, lte: endUtc } });
+    expect(arg.where).toEqual({ userId: 'user1', dueAt: { gte: startUtc, lte: endUtc } });
   });
 });
 

--- a/src/server/api/routers/task.ts
+++ b/src/server/api/routers/task.ts
@@ -47,7 +47,7 @@ export const taskRouter = router({
       const priority = input?.priority;
       const courseId = input?.courseId;
       const projectId = input?.projectId;
-      const parentId = input?.parentId ?? null;
+      const parentId = input?.parentId;
       const tzOffsetMinutes = input?.tzOffsetMinutes ?? null;
       const nowUtc = new Date();
 
@@ -85,8 +85,8 @@ export const taskRouter = router({
       // Show only DONE in archive; otherwise include all by default
       const baseWhere: Prisma.TaskWhereInput =
         filter === 'archive'
-          ? { status: TaskStatus.DONE, userId, parentId }
-          : { userId, parentId };
+          ? { status: TaskStatus.DONE, userId }
+          : { userId };
 
       let where: Prisma.TaskWhereInput =
         filter === 'overdue'
@@ -107,7 +107,7 @@ export const taskRouter = router({
       if (projectId) {
         where = { ...where, projectId };
       }
-      if (input?.parentId !== undefined) {
+      if (parentId !== undefined) {
         where = { ...where, parentId };
       }
 


### PR DESCRIPTION
## Summary
- allow task list queries to include subtasks unless a parentId is specified
- update task router tests for optional parent filter

## Testing
- `npm run lint`
- `CI=true npm test src/server/api/routers/task.test.ts`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b64d3d163083208f5dec7042d57b1f