### PR TITLE
feat: add color swatch buttons

### DIFF
--- a/src/app/courses/page.test.tsx
+++ b/src/app/courses/page.test.tsx
@@ -93,11 +93,11 @@ describe('CoursesPage', () => {
     listMock.mockReturnValue({ data: [], isLoading: false, error: undefined });
     createMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
     render(<CoursesPage />);
-    const select = screen.getByLabelText('Course color') as HTMLSelectElement;
-    const swatch = screen.getByTestId('color-preview');
-    expect(swatch).toHaveStyle({ backgroundColor: '#000000' });
-    fireEvent.change(select, { target: { value: '#FF0000' } });
-    expect(swatch).toHaveStyle({ backgroundColor: '#FF0000' });
+    const preview = screen.getByTestId('color-preview');
+    expect(preview).toHaveStyle({ backgroundColor: '#000000' });
+    const swatch = screen.getByRole('button', { name: 'Select color #FF0000' });
+    fireEvent.click(swatch);
+    expect(preview).toHaveStyle({ backgroundColor: '#FF0000' });
   });
 
   it('sorts courses by title by default and toggles to term', () => {

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 import React, { useState, useEffect } from "react";
 import { ArrowUpDown as ArrowUpDownIcon } from "lucide-react";
+import { TrashIcon, CheckIcon, CaretSortIcon } from "@radix-ui/react-icons";
+import { clsx } from "clsx";
 import { Button } from "@/components/ui/button";
 import { CourseSkeleton } from "@/components/CourseSkeleton";
 import { api } from "@/server/api/react";
 import { toast } from "@/lib/toast";
-import { TrashIcon, CheckIcon, CaretSortIcon } from "@radix-ui/react-icons";
 
 const COLOR_OPTIONS = [
   "#000000",
@@ -123,24 +124,35 @@ export default function CoursesPage() {
                 onChange={(e) => setTerm(e.target.value)}
               />
             </label>
-            <label htmlFor="course-color" className="flex flex-col gap-1">
-              Color (optional)
-              <div className="flex items-center gap-2">
-                <input
-                  id="course-color"
-                  type="color"
-                  aria-label="Course color"
-                  className="h-10 w-10 rounded border border-black/10 bg-transparent p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
-                  value={color || "#000000"}
-                  onChange={(e) => setColor(e.target.value)}
-                />
+            <div className="flex flex-col gap-1">
+              <span>Color (optional)</span>
+              <div
+                role="group"
+                aria-label="Course color"
+                className="flex items-center gap-2"
+              >
+                <div className="flex flex-wrap gap-2">
+                  {COLOR_OPTIONS.map((c) => (
+                    <button
+                      key={c}
+                      type="button"
+                      aria-label={`Select color ${c}`}
+                      className={clsx(
+                        "h-10 w-10 rounded border border-black/10 p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10",
+                        color === c && "ring-2 ring-indigo-500 ring-offset-2",
+                      )}
+                      style={{ backgroundColor: c }}
+                      onClick={() => setColor(color === c ? "" : c)}
+                    />
+                  ))}
+                </div>
                 <div
                   data-testid="color-preview"
                   className="h-6 w-6 rounded border border-black/10 dark:border-white/10"
                   style={{ backgroundColor: color || "#000000" }}
                 />
               </div>
-            </label>
+            </div>
             <Button type="submit" disabled={isAddDisabled}>
               Add Course
             </Button>
@@ -203,7 +215,7 @@ export default function CoursesPage() {
                   (termFilter === "" || c.term === termFilter),
               )
               .map((c) => (
-                <CourseItem key={c.id} course={c} />
+                <CourseItem key={c.id} course={c} onPendingChange={() => {}} />
               ))}
           </ul>
         </div>


### PR DESCRIPTION
## Summary
- map predefined COLOR_OPTIONS to clickable buttons
- show selected color preview and remove color input field
- update course page tests for swatch selection

## Testing
- `npm run lint`
- `CI=true npm test` (fails: api.task.list.useQuery is not a function)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b656c460148320a0676c9bd3b00b63