### PR TITLE
feat: add icons to course sorting buttons

### DIFF
--- a/src/app/courses/page.test.tsx
+++ b/src/app/courses/page.test.tsx
@@ -131,9 +131,7 @@ describe('CoursesPage', () => {
     render(<CoursesPage />);
     const items = screen.getAllByRole('listitem');
     expect(within(items[0]).getAllByRole('textbox')[0]).toHaveValue('A');
-    fireEvent.click(
-      screen.getByRole('button', { name: /toggle sort direction/i }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: /sort by title/i }));
     const itemsAfter = screen.getAllByRole('listitem');
     expect(within(itemsAfter[0]).getAllByRole('textbox')[0]).toHaveValue('B');
   });

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -1,11 +1,14 @@
 "use client";
 import React, { useState, useEffect } from "react";
-import { ArrowUpDown as ArrowUpDownIcon } from "lucide-react";
+import {
+  ArrowUp as ArrowUpIcon,
+  ArrowDown as ArrowDownIcon,
+} from "lucide-react";
+import { CaretSortIcon } from "@radix-ui/react-icons";
 import { Button } from "@/components/ui/button";
 import { CourseSkeleton } from "@/components/CourseSkeleton";
 import { api } from "@/server/api/react";
 import { toast } from "@/lib/toast";
-import { TrashIcon, CheckIcon, CaretSortIcon } from "@radix-ui/react-icons";
 
 const COLOR_OPTIONS = [
   "#000000",
@@ -149,23 +152,48 @@ export default function CoursesPage() {
         </div>
         <div className="flex gap-2">
           <Button
-            variant={sortBy === "title" ? "primary" : "secondary"}
-            onClick={() => setSortBy("title")}
+            variant={sortBy === "title" ? "secondary" : "tertiary"}
+            onClick={() => {
+              if (sortBy === "title") {
+                setSortDir(sortDir === "asc" ? "desc" : "asc");
+              } else {
+                setSortBy("title");
+                setSortDir("asc");
+              }
+            }}
           >
             Sort by Title
+            {sortBy === "title" ? (
+              sortDir === "asc" ? (
+                <ArrowUpIcon className="ml-2 h-4 w-4" />
+              ) : (
+                <ArrowDownIcon className="ml-2 h-4 w-4" />
+              )
+            ) : (
+              <CaretSortIcon className="ml-2 h-4 w-4" />
+            )}
           </Button>
           <Button
-            variant={sortBy === "term" ? "primary" : "secondary"}
-            onClick={() => setSortBy("term")}
+            variant={sortBy === "term" ? "secondary" : "tertiary"}
+            onClick={() => {
+              if (sortBy === "term") {
+                setSortDir(sortDir === "asc" ? "desc" : "asc");
+              } else {
+                setSortBy("term");
+                setSortDir("asc");
+              }
+            }}
           >
             Sort by Term
-          </Button>
-          <Button
-            variant="tertiary"
-            onClick={() => setSortDir(sortDir === "asc" ? "desc" : "asc")}
-            aria-label="Toggle sort direction"
-          >
-            <ArrowUpDownIcon className="h-4 w-4" />
+            {sortBy === "term" ? (
+              sortDir === "asc" ? (
+                <ArrowUpIcon className="ml-2 h-4 w-4" />
+              ) : (
+                <ArrowDownIcon className="ml-2 h-4 w-4" />
+              )
+            ) : (
+              <CaretSortIcon className="ml-2 h-4 w-4" />
+            )}
           </Button>
         </div>
         <div className="max-w-md">
@@ -203,7 +231,11 @@ export default function CoursesPage() {
                   (termFilter === "" || c.term === termFilter),
               )
               .map((c) => (
-                <CourseItem key={c.id} course={c} />
+                <CourseItem
+                  key={c.id}
+                  course={c}
+                  onPendingChange={() => {}}
+                />
               ))}
           </ul>
         </div>


### PR DESCRIPTION
## Summary
- show directional icons within course sort buttons
- highlight active sort field via button variants
- update tests for in-button sort toggling

## Testing
- `npm run lint`
- `CI=true npm test` *(fails: api.task.list.useQuery is not a function)*
- `npm run build` *(fails: property 'instructionsUrl' missing in projects page)*

------
https://chatgpt.com/codex/tasks/task_e_68b656c9185c8320abdea54f06454c66