### PR TITLE
feat: add alert dialog for course deletion

### DIFF
--- a/src/app/courses/page.test.tsx
+++ b/src/app/courses/page.test.tsx
@@ -204,4 +204,24 @@ describe('CoursesPage', () => {
     expect(screen.getByDisplayValue('History')).toBeInTheDocument();
     expect(screen.queryByDisplayValue('Math')).toBeNull();
   });
+
+  it('confirms before deleting a course', () => {
+    listMock.mockReturnValue({
+      data: [{ id: '1', title: 'Course', term: null, color: null }],
+      isLoading: false,
+      error: undefined,
+    });
+    createMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
+    updateMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
+    const mutate = vi.fn();
+    deleteMock.mockReturnValue({ mutate, isPending: false, error: undefined });
+
+    render(<CoursesPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+    const dialog = screen.getByRole('alertdialog');
+    expect(dialog).toBeInTheDocument();
+    fireEvent.click(within(dialog).getByRole('button', { name: /^delete$/i }));
+    expect(mutate).toHaveBeenCalledWith({ id: '1' });
+  });
 });

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from "react";
 import { ArrowUpDown as ArrowUpDownIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { AlertDialog } from "@/components/ui/alert-dialog";
 import { CourseSkeleton } from "@/components/CourseSkeleton";
 import { api } from "@/server/api/react";
 import { toast } from "@/lib/toast";
@@ -203,7 +204,11 @@ export default function CoursesPage() {
                   (termFilter === "" || c.term === termFilter),
               )
               .map((c) => (
-                <CourseItem key={c.id} course={c} />
+                <CourseItem
+                  key={c.id}
+                  course={c}
+                  onPendingChange={() => {}}
+                />
               ))}
           </ul>
         </div>
@@ -212,7 +217,7 @@ export default function CoursesPage() {
   );
 }
 
-function CourseItem({
+export function CourseItem({
   course,
   onPendingChange,
 }: {
@@ -246,6 +251,7 @@ function CourseItem({
   const [term, setTerm] = useState(course.term ?? "");
   const [color, setColor] = useState(course.color ?? "");
   const [hasPendingChanges, setHasPendingChanges] = useState(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const titleId = `course-${course.id}-title`;
   const termId = `course-${course.id}-term`;
   const colorId = `course-${course.id}-color`;
@@ -330,15 +336,22 @@ function CourseItem({
           <Button
             variant="danger"
             disabled={isDeleting}
-            onClick={() => {
-              if (window.confirm("Delete this course?")) {
-                deleteCourse({ id: course.id });
-              }
-            }}
+            onClick={() => setShowDeleteDialog(true)}
           >
             Delete
           </Button>
         </div>
+        <AlertDialog
+          open={showDeleteDialog}
+          title="Delete this course?"
+          onCancel={() => setShowDeleteDialog(false)}
+          onConfirm={() => {
+            deleteCourse({ id: course.id });
+            setShowDeleteDialog(false);
+          }}
+          confirmText="Delete"
+          confirmDisabled={isDeleting}
+        />
         {updateError && <p className="text-red-500">{updateError.message}</p>}
         {deleteError && <p className="text-red-500">{deleteError.message}</p>}
       </div>

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Button } from './button';
+
+interface AlertDialogProps {
+  open: boolean;
+  title?: string;
+  description?: string;
+  confirmText?: string;
+  cancelText?: string;
+  confirmDisabled?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function AlertDialog({
+  open,
+  title,
+  description,
+  confirmText = 'Confirm',
+  cancelText = 'Cancel',
+  confirmDisabled,
+  onConfirm,
+  onCancel,
+}: AlertDialogProps) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div
+        role="alertdialog"
+        aria-modal="true"
+        className="w-full max-w-sm rounded bg-card p-6 shadow-lg"
+      >
+        {title && <h2 className="text-lg font-semibold">{title}</h2>}
+        {description && <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">{description}</p>}
+        <div className="mt-6 flex justify-end gap-2">
+          <Button variant="secondary" onClick={onCancel}>
+            {cancelText}
+          </Button>
+          <Button variant="danger" disabled={confirmDisabled} onClick={onConfirm}>
+            {confirmText}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AlertDialog;
+


### PR DESCRIPTION
## Summary
- add reusable AlertDialog component
- use AlertDialog to confirm course deletions
- cover course deletion flow with unit test

## Testing
- `npm run lint`
- `CI=true npx vitest run src/app/courses/page.test.tsx -t "confirms before deleting a course"`
- `npm run build` *(fails: Object literal may only specify known properties, and 'parentId' does not exist in type 'TaskWhereInput')*


------
https://chatgpt.com/codex/tasks/task_e_68b656cf302c8320a8305fbe613528cc