### PR TITLE
feat: show title validation error

### DIFF
--- a/src/components/task-modal.test.tsx
+++ b/src/components/task-modal.test.tsx
@@ -86,6 +86,20 @@ describe('TaskModal due date editing', () => {
   });
 });
 
+describe('TaskModal validation', () => {
+  beforeEach(() => {
+    mutateCreate.mockReset();
+    createMutation.error = undefined;
+  });
+
+  it('shows an error when title is missing', () => {
+    render(<TaskModal open mode="create" onClose={() => {}} />);
+    fireEvent.click(screen.getByText('Create'));
+    expect(screen.getByText('Title is required')).toBeInTheDocument();
+    expect(mutateCreate).not.toHaveBeenCalled();
+  });
+});
+
   describe('TaskModal project and course selection', () => {
   beforeEach(() => {
     mutateCreate.mockReset();

--- a/src/components/task-modal.tsx
+++ b/src/components/task-modal.tsx
@@ -38,6 +38,7 @@ export function TaskModal({
   const apiAny = api as any;
 
   const [title, setTitle] = useState("");
+  const [titleError, setTitleError] = useState<string | null>(null);
   const [subject, setSubject] = useState<string>("");
   const [notes, setNotes] = useState<string>("");
   const [due, setDue] = useState<string>(""); // datetime-local
@@ -95,6 +96,7 @@ export function TaskModal({
         setDueEnabled(false);
       }
     }
+    setTitleError(null);
   }, [open, isEdit, task, initialTitle, initialDueAt, initialProjectId]);
 
   const create = api.task.create.useMutation({
@@ -176,6 +178,7 @@ export function TaskModal({
             });
           } else {
             if (!title.trim()) {
+              setTitleError("Title is required");
               return;
             }
             create.mutate({
@@ -218,13 +221,21 @@ export function TaskModal({
           <label htmlFor="title" className="w-28 text-sm font-medium">
             Title
           </label>
-          <input
-            id="title"
-            className="flex-1 rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
-            placeholder="Task title"
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-          />
+          <div className="flex-1">
+            <input
+              id="title"
+              className="w-full rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
+              placeholder="Task title"
+              value={title}
+              onChange={(e) => {
+                setTitle(e.target.value);
+                if (titleError) setTitleError(null);
+              }}
+            />
+            {titleError && (
+              <p className="mt-1 text-sm text-red-600">{titleError}</p>
+            )}
+          </div>
         </div>
   
         <div className="flex items-center gap-4">


### PR DESCRIPTION
## Summary
- handle local title validation errors
- display message under the title field when empty

## Testing
- `npm run lint`
- `CI=true npm test src/components/task-modal.test.tsx`
- `npm run build` *(fails: Property 'onPendingChange' is missing in `CourseItem`)*

------
https://chatgpt.com/codex/tasks/task_e_68b656d7a6e48320bdb3152b28e9f1b2