### PR TITLE
feat: filter courses by search and term

### DIFF
--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -22,11 +22,6 @@ export default function CoursesPage() {
   const [page, setPage] = useState(1);
   const limit = 10;
   const {
-    data: courses = [],
-    isLoading,
-    error,
-  } = api.course.list.useQuery({ page, limit });
-  const {
     mutate: createCourse,
     isPending: isCreating,
     error: createError,
@@ -45,6 +40,16 @@ export default function CoursesPage() {
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const [termFilter, setTermFilter] = useState("");
+  const {
+    data: courses = [],
+    isLoading,
+    error,
+  } = api.course.list.useQuery({
+    page,
+    limit,
+    search: debouncedSearch,
+    term: termFilter,
+  });
   const isAddDisabled = isCreating || title.trim() === "";
 
   useEffect(() => {
@@ -94,8 +99,6 @@ export default function CoursesPage() {
     setTerm("");
     setColor("");
   };
-
-  const query = debouncedSearch.toLowerCase();
 
   return (
     <div className="container mx-auto px-4">
@@ -194,17 +197,9 @@ export default function CoursesPage() {
             onChange={(e) => setSearch(e.target.value)}
           />
           <ul className="space-y-4">
-            {sortedCourses
-              .filter(
-                (c) =>
-                  c.title
-                    .toLowerCase()
-                    .includes(debouncedSearch.toLowerCase()) &&
-                  (termFilter === "" || c.term === termFilter),
-              )
-              .map((c) => (
-                <CourseItem key={c.id} course={c} />
-              ))}
+            {sortedCourses.map((c) => (
+              <CourseItem key={c.id} course={c} onPendingChange={() => {}} />
+            ))}
           </ul>
         </div>
       </main>

--- a/src/server/api/routers/course.test.ts
+++ b/src/server/api/routers/course.test.ts
@@ -34,6 +34,20 @@ describe('courseRouter.list', () => {
     await courseRouter.createCaller(ctx).list({ page: 2, limit: 5 });
     expect(hoisted.findMany).toHaveBeenCalledWith({ where: { userId: 'user1' }, skip: 5, take: 5 });
   });
+  it('applies search and term filters', async () => {
+    await courseRouter
+      .createCaller(ctx)
+      .list({ page: 1, limit: 10, search: 'math', term: 'fall' });
+    expect(hoisted.findMany).toHaveBeenCalledWith({
+      where: {
+        userId: 'user1',
+        title: { contains: 'math', mode: 'insensitive' },
+        term: 'fall',
+      },
+      skip: 0,
+      take: 10,
+    });
+  });
 });
 
 describe('courseRouter.create', () => {

--- a/src/server/api/routers/course.ts
+++ b/src/server/api/routers/course.ts
@@ -9,13 +9,21 @@ export const courseRouter = router({
       z.object({
         page: z.number().int().min(1).default(1),
         limit: z.number().int().min(1).max(100).default(10),
+        search: z.string().optional(),
+        term: z.string().optional(),
       })
     )
     .query(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
-      const { page, limit } = input;
+      const { page, limit, search, term } = input;
       return db.course.findMany({
-        where: { userId },
+        where: {
+          userId,
+          ...(search
+            ? { title: { contains: search, mode: 'insensitive' } }
+            : {}),
+          ...(term ? { term } : {}),
+        },
         skip: (page - 1) * limit,
         take: limit,
       });


### PR DESCRIPTION
## Summary
- support searching and filtering courses by term on the server
- wire search and term filters through client query
- test course list filtering by search and term

## Testing
- `npm run lint`
- `npm test` *(fails: api.task.list.useQuery is not a function)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b656e13b408320a44ad1ecfcd23dda