### PR TITLE
feat: add bulk course delete

### DIFF
--- a/src/server/api/routers/course.test.ts
+++ b/src/server/api/routers/course.test.ts
@@ -7,7 +7,8 @@ const hoisted = vi.hoisted(() => {
   const create = vi.fn().mockResolvedValue({});
   const update = vi.fn().mockResolvedValue({});
   const del = vi.fn().mockResolvedValue({});
-  return { findMany, findFirst, create, update, delete: del };
+  const delMany = vi.fn().mockResolvedValue({});
+  return { findMany, findFirst, create, update, delete: del, deleteMany: delMany };
 });
 
 vi.mock('@/server/db', () => ({
@@ -18,6 +19,7 @@ vi.mock('@/server/db', () => ({
       create: hoisted.create,
       update: hoisted.update,
       delete: hoisted.delete,
+      deleteMany: hoisted.deleteMany,
     },
   },
 }));
@@ -72,6 +74,18 @@ describe('courseRouter.delete', () => {
   it('deletes course by id for user', async () => {
     await courseRouter.createCaller(ctx).delete({ id: '1' });
     expect(hoisted.delete).toHaveBeenCalledWith({ where: { id: '1', userId: 'user1' } });
+  });
+});
+
+describe('courseRouter.deleteMany', () => {
+  beforeEach(() => {
+    hoisted.deleteMany.mockClear();
+  });
+  it('deletes courses by ids for user', async () => {
+    await courseRouter.createCaller(ctx).deleteMany({ ids: ['1', '2'] });
+    expect(hoisted.deleteMany).toHaveBeenCalledWith({
+      where: { id: { in: ['1', '2'] }, userId: 'user1' },
+    });
   });
 });
 

--- a/src/server/api/routers/course.ts
+++ b/src/server/api/routers/course.ts
@@ -75,6 +75,14 @@ export const courseRouter = router({
       const userId = ctx.session.user.id;
       return db.course.delete({ where: { id: input.id, userId } });
     }),
+  deleteMany: protectedProcedure
+    .input(z.object({ ids: z.array(z.string().min(1)) }))
+    .mutation(async ({ input, ctx }) => {
+      const userId = ctx.session.user.id;
+      return db.course.deleteMany({
+        where: { id: { in: input.ids }, userId },
+      });
+    }),
 });
 
 export default courseRouter;


### PR DESCRIPTION
## Summary
- add checkboxes and bulk delete control to courses page
- support deleting multiple courses with new API endpoint
- cover bulk delete with unit and integration tests

## Testing
- `npm run lint`
- `npx vitest run src/app/courses/page.test.tsx src/server/api/routers/course.test.ts`
- `npm run build` *(fails: Creating an optimized production build ... hangs, likely environment issue)*

------
https://chatgpt.com/codex/tasks/task_e_68b656e46a4c8320957b3dbe46ec5449