### PR TITLE
feat: add course description field

### DIFF
--- a/prisma/migrations/20250821230254_add_course_description/migration.sql
+++ b/prisma/migrations/20250821230254_add_course_description/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Course" ADD COLUMN "description" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,6 +76,7 @@ model Course {
   title  String
   term   String?
   color  String?
+  description String?
 
   tasks Task[]
 }

--- a/src/app/courses/page.test.tsx
+++ b/src/app/courses/page.test.tsx
@@ -57,11 +57,11 @@ describe('CoursesPage', () => {
     });
 
   it('disables save and delete buttons and shows errors', () => {
-    listMock.mockReturnValue({
-      data: [{ id: '1', title: 'Course', term: null, color: null }],
-      isLoading: false,
-      error: undefined,
-    });
+      listMock.mockReturnValue({
+        data: [{ id: '1', title: 'Course', term: null, color: null, description: null }],
+        isLoading: false,
+        error: undefined,
+      });
     createMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
     updateMock.mockReturnValue({ mutate: vi.fn(), isPending: true, error: { message: 'Update failed' } });
     deleteMock.mockReturnValue({ mutate: vi.fn(), isPending: true, error: { message: 'Delete failed' } });
@@ -73,11 +73,11 @@ describe('CoursesPage', () => {
   });
 
   it('shows error toast when course title exists', () => {
-    listMock.mockReturnValue({
-      data: [{ id: '1', title: 'Math', term: null, color: null }],
-      isLoading: false,
-      error: undefined,
-    });
+      listMock.mockReturnValue({
+        data: [{ id: '1', title: 'Math', term: null, color: null, description: null }],
+        isLoading: false,
+        error: undefined,
+      });
     const mutate = vi.fn();
     createMock.mockReturnValue({ mutate, isPending: false, error: undefined });
     render(<CoursesPage />);
@@ -101,10 +101,10 @@ describe('CoursesPage', () => {
   });
 
   it('sorts courses by title by default and toggles to term', () => {
-    const mockCourses = [
-      { id: '1', title: 'B', term: 'Summer', color: null },
-      { id: '2', title: 'A', term: 'Winter', color: null },
-    ];
+      const mockCourses = [
+        { id: '1', title: 'B', term: 'Summer', color: null, description: null },
+        { id: '2', title: 'A', term: 'Winter', color: null, description: null },
+      ];
     listMock.mockReturnValue({ data: mockCourses, isLoading: false, error: undefined });
     createMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
     updateMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
@@ -119,10 +119,10 @@ describe('CoursesPage', () => {
   });
 
   it('toggles sort direction', () => {
-    const mockCourses = [
-      { id: '1', title: 'A', term: 'Fall', color: null },
-      { id: '2', title: 'B', term: 'Spring', color: null },
-    ];
+      const mockCourses = [
+        { id: '1', title: 'A', term: 'Fall', color: null, description: null },
+        { id: '2', title: 'B', term: 'Spring', color: null, description: null },
+      ];
     listMock.mockReturnValue({ data: mockCourses, isLoading: false, error: undefined });
     createMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
     updateMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
@@ -140,14 +140,14 @@ describe('CoursesPage', () => {
 
   it('filters courses by search input', () => {
     vi.useFakeTimers();
-    listMock.mockReturnValue({
-      data: [
-        { id: '1', title: 'Math', term: 'Fall', color: '#ABCDEF' },
-        { id: '2', title: 'History', term: 'Spring', color: '#123456' },
-      ],
-      isLoading: false,
-      error: undefined,
-    });
+      listMock.mockReturnValue({
+        data: [
+          { id: '1', title: 'Math', term: 'Fall', color: '#ABCDEF', description: 'Algebra' },
+          { id: '2', title: 'History', term: 'Spring', color: '#123456', description: 'World events' },
+        ],
+        isLoading: false,
+        error: undefined,
+      });
     createMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
     updateMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
     deleteMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
@@ -172,26 +172,34 @@ describe('CoursesPage', () => {
     expect(screen.getByDisplayValue('History')).toBeInTheDocument();
     expect(screen.queryByDisplayValue('Math')).toBeNull();
 
-    // filter by color
-    fireEvent.change(input, { target: { value: '#abcdef' } });
-    act(() => {
-      vi.advanceTimersByTime(400);
-    });
-    expect(screen.getByDisplayValue('Math')).toBeInTheDocument();
-    expect(screen.queryByDisplayValue('History')).toBeNull();
+      // filter by color
+      fireEvent.change(input, { target: { value: '#abcdef' } });
+      act(() => {
+        vi.advanceTimersByTime(400);
+      });
+      expect(screen.getByDisplayValue('Math')).toBeInTheDocument();
+      expect(screen.queryByDisplayValue('History')).toBeNull();
 
-    vi.useRealTimers();
+      // filter by description
+      fireEvent.change(input, { target: { value: 'world' } });
+      act(() => {
+        vi.advanceTimersByTime(400);
+      });
+      expect(screen.getByDisplayValue('History')).toBeInTheDocument();
+      expect(screen.queryByDisplayValue('Math')).toBeNull();
+
+      vi.useRealTimers();
   });
 
   it('filters courses by selected term', () => {
-    listMock.mockReturnValue({
-      data: [
-        { id: '1', title: 'Math', term: 'Fall', color: null },
-        { id: '2', title: 'History', term: 'Spring', color: null },
-      ],
-      isLoading: false,
-      error: undefined,
-    });
+      listMock.mockReturnValue({
+        data: [
+          { id: '1', title: 'Math', term: 'Fall', color: null, description: null },
+          { id: '2', title: 'History', term: 'Spring', color: null, description: null },
+        ],
+        isLoading: false,
+        error: undefined,
+      });
     createMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
     updateMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
     deleteMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -40,6 +40,7 @@ export default function CoursesPage() {
   const [title, setTitle] = useState("");
   const [term, setTerm] = useState("");
   const [color, setColor] = useState("");
+  const [description, setDescription] = useState("");
   const [sortBy, setSortBy] = useState<"title" | "term">("title");
   const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
   const [search, setSearch] = useState("");
@@ -89,10 +90,16 @@ export default function CoursesPage() {
       toast.error("Course already exists.");
       return;
     }
-    createCourse({ title: t, term: term.trim() || undefined, color: color.trim() || undefined });
+    createCourse({
+      title: t,
+      term: term.trim() || undefined,
+      color: color.trim() || undefined,
+      description: description.trim() || undefined,
+    });
     setTitle("");
     setTerm("");
     setColor("");
+    setDescription("");
   };
 
   const query = debouncedSearch.toLowerCase();
@@ -121,6 +128,16 @@ export default function CoursesPage() {
                 placeholder="Term (optional)"
                 value={term}
                 onChange={(e) => setTerm(e.target.value)}
+              />
+            </label>
+            <label htmlFor="course-description" className="flex flex-col gap-1">
+              Description (optional)
+              <textarea
+                id="course-description"
+                className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
+                placeholder="Description (optional)"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
               />
             </label>
             <label htmlFor="course-color" className="flex flex-col gap-1">
@@ -193,20 +210,20 @@ export default function CoursesPage() {
             value={search}
             onChange={(e) => setSearch(e.target.value)}
           />
-          <ul className="space-y-4">
-            {sortedCourses
-              .filter(
-                (c) =>
-                  c.title
-                    .toLowerCase()
-                    .includes(debouncedSearch.toLowerCase()) &&
-                  (termFilter === "" || c.term === termFilter),
-              )
-              .map((c) => (
-                <CourseItem key={c.id} course={c} />
-              ))}
-          </ul>
-        </div>
+            <ul className="space-y-4">
+              {sortedCourses
+                .filter(
+                  (c) =>
+                    [c.title, c.term ?? "", c.color ?? "", c.description ?? ""].some((f) =>
+                      f.toLowerCase().includes(query),
+                    ) &&
+                    (termFilter === "" || c.term === termFilter),
+                )
+                .map((c) => (
+                  <CourseItem key={c.id} course={c} />
+                ))}
+            </ul>
+          </div>
       </main>
     </div>
   );
@@ -214,10 +231,10 @@ export default function CoursesPage() {
 
 function CourseItem({
   course,
-  onPendingChange,
+  onPendingChange = () => {},
 }: {
-  course: { id: string; title: string; term: string | null; color: string | null };
-  onPendingChange: (id: string, pending: boolean) => void;
+  course: { id: string; title: string; term: string | null; color: string | null; description: string | null };
+  onPendingChange?: (id: string, pending: boolean) => void;
 }) {
   const utils = api.useUtils();
   const {
@@ -245,17 +262,21 @@ function CourseItem({
   const [title, setTitle] = useState(course.title);
   const [term, setTerm] = useState(course.term ?? "");
   const [color, setColor] = useState(course.color ?? "");
+  const [description, setDescription] = useState(course.description ?? "");
   const [hasPendingChanges, setHasPendingChanges] = useState(false);
   const titleId = `course-${course.id}-title`;
   const termId = `course-${course.id}-term`;
   const colorId = `course-${course.id}-color`;
+  const descriptionId = `course-${course.id}-description`;
   const trimmedTitle = title.trim();
   const trimmedTerm = term.trim();
   const trimmedColor = color.trim();
+  const trimmedDescription = description.trim();
   const hasChanges =
     trimmedTitle !== course.title ||
     trimmedTerm !== (course.term ?? "") ||
-    trimmedColor !== (course.color ?? "");
+    trimmedColor !== (course.color ?? "") ||
+    trimmedDescription !== (course.description ?? "");
 
   useEffect(() => {
     setHasPendingChanges(hasChanges);
@@ -296,6 +317,15 @@ function CourseItem({
             onChange={(e) => setTerm(e.target.value)}
           />
         </label>
+        <label htmlFor={descriptionId} className="flex flex-col gap-1">
+          Description
+          <textarea
+            id={descriptionId}
+            className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+        </label>
         <label htmlFor={colorId} className="flex flex-col gap-1">
           Color
           <div className="flex items-center gap-2">
@@ -322,6 +352,7 @@ function CourseItem({
                 title: trimmedTitle,
                 term: trimmedTerm || null,
                 color: trimmedColor || null,
+                description: trimmedDescription || null,
               })
             }
           >

--- a/src/components/task-filter-tabs.test.tsx
+++ b/src/components/task-filter-tabs.test.tsx
@@ -21,7 +21,7 @@ vi.mock('@/server/api/react', () => ({
         }),
       },
     },
-    course: { list: { useQuery: () => ({ data: [{ id: 'c1', title: 'Course 1' }] }) } },
+    course: { list: { useQuery: () => ({ data: [{ id: 'c1', title: 'Course 1', description: null }] }) } },
     project: { list: { useQuery: () => ({ data: [{ id: 'p1', title: 'Project 1' }] }) } },
   },
 }));

--- a/src/components/task-modal.test.tsx
+++ b/src/components/task-modal.test.tsx
@@ -30,7 +30,7 @@ vi.mock('@/server/api/react', () => ({
       list: { useQuery: () => ({ data: [] }) },
     },
     project: { list: { useQuery: () => ({ data: [{ id: 'p1', title: 'Project 1' }] }) } },
-    course: { list: { useQuery: () => ({ data: [{ id: 'c1', title: 'Course 1' }] }) } },
+    course: { list: { useQuery: () => ({ data: [{ id: 'c1', title: 'Course 1', description: null }] }) } },
   },
 }));
 

--- a/src/server/api/routers/course.test.ts
+++ b/src/server/api/routers/course.test.ts
@@ -42,8 +42,8 @@ describe('courseRouter.create', () => {
     hoisted.findFirst.mockClear();
   });
   it('creates course with title and optional fields', async () => {
-    await courseRouter.createCaller(ctx).create({ title: 'c', term: 'fall', color: 'red' });
-    expect(hoisted.create).toHaveBeenCalledWith({ data: { title: 'c', userId: 'user1', term: 'fall', color: 'red' } });
+    await courseRouter.createCaller(ctx).create({ title: 'c', term: 'fall', color: 'red', description: 'd' });
+    expect(hoisted.create).toHaveBeenCalledWith({ data: { title: 'c', userId: 'user1', term: 'fall', color: 'red', description: 'd' } });
   });
   it('throws if course title exists', async () => {
     hoisted.findFirst.mockResolvedValueOnce({ id: '1', title: 'c' });
@@ -60,8 +60,8 @@ describe('courseRouter.update', () => {
     hoisted.update.mockClear();
   });
   it('updates course fields', async () => {
-    await courseRouter.createCaller(ctx).update({ id: '1', title: 'nc', term: null, color: null });
-    expect(hoisted.update).toHaveBeenCalledWith({ where: { id: '1', userId: 'user1' }, data: { title: 'nc', term: null, color: null } });
+    await courseRouter.createCaller(ctx).update({ id: '1', title: 'nc', term: null, color: null, description: null });
+    expect(hoisted.update).toHaveBeenCalledWith({ where: { id: '1', userId: 'user1' }, data: { title: 'nc', term: null, color: null, description: null } });
   });
 });
 

--- a/src/server/api/routers/course.ts
+++ b/src/server/api/routers/course.ts
@@ -26,6 +26,7 @@ export const courseRouter = router({
         title: z.string().min(1).max(200),
         term: z.string().max(100).optional(),
         color: z.string().max(50).optional(),
+        description: z.string().max(1000).optional(),
       })
     )
     .mutation(async ({ input, ctx }) => {
@@ -45,6 +46,7 @@ export const courseRouter = router({
           userId,
           term: input.term ?? null,
           color: input.color ?? null,
+          description: input.description ?? null,
         },
       });
     }),
@@ -55,6 +57,7 @@ export const courseRouter = router({
         title: z.string().min(1).max(200).optional(),
         term: z.string().max(100).nullable().optional(),
         color: z.string().max(50).nullable().optional(),
+        description: z.string().max(1000).nullable().optional(),
       })
     )
     .mutation(async ({ input, ctx }) => {


### PR DESCRIPTION
## Summary
- allow storing optional course description in Prisma schema and API
- support description in course creation/update forms
- extend tests for course filtering and router behavior

## Testing
- `npm run lint`
- `CI=true npx vitest run src/components/task-modal.test.tsx`
- `CI=true npx vitest run src/server/api/routers/course.test.ts src/app/courses/page.test.tsx src/components/task-filter-tabs.test.tsx`
- `npm run build` *(fails: process hung after type checking)*

------
https://chatgpt.com/codex/tasks/task_e_68b656e8179483208a3fe7dee457d579