### PR TITLE
feat: add calendar loading state

### DIFF
--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -204,6 +204,20 @@ export default function CalendarPage() {
     </div>
   );
 
+  if (tasksQ.isLoading || eventsQ.isLoading) {
+    return (
+      <ErrorBoundary fallback={<main>Failed to load calendar</main>}>
+        <main className="flex items-center justify-center p-4">
+          <div
+            aria-label="loading calendar"
+            role="status"
+            className="h-10 w-10 animate-spin rounded-full border-4 border-black/10 border-t-black dark:border-white/10 dark:border-t-white"
+          />
+        </main>
+      </ErrorBoundary>
+    );
+  }
+
   if (focusedTaskId) {
     const task = tasksData.find((t) => t.id === focusedTaskId);
     return (


### PR DESCRIPTION
## Summary
- show spinner while calendar data loads
- hide backlog and grid until queries resolve
- test calendar loading indicator

## Testing
- `npm run lint`
- `npm test src/app/calendar/page.test.tsx`
- `npm run build` *(fails: Property 'onPendingChange' is missing in CourseItem)*

------
https://chatgpt.com/codex/tasks/task_e_68b65722c6c88320a12eeb2fd8916084