### PR TITLE
feat: extract duration utility

### DIFF
--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { api } from '@/server/api/react';
 import type { RouterOutputs } from '@/server/api/root';
+import { calculateDurationMinutes } from '@/lib/datetime';
 import { CalendarGrid, DraggableTask } from '@/components/calendar/CalendarGrid';
 import { ErrorBoundary } from '@/components/error-boundary';
 
@@ -298,7 +299,7 @@ export default function CalendarPage() {
             const startAt = new Date(iso);
             const ev = eventsLocal.find((e) => e.id === eventId);
             if (!ev) return;
-            const durationMin = Math.max(1, Math.round((new Date(ev.endAt).getTime() - new Date(ev.startAt).getTime()) / 60000));
+            const durationMin = calculateDurationMinutes(ev.startAt, ev.endAt);
             const endAt = new Date(startAt.getTime() + durationMin * 60000);
             // optimistic update
             setEventsLocal((prev) => prev.map((x) => x.id === eventId ? { ...x, startAt, endAt } : x));
@@ -367,7 +368,7 @@ export default function CalendarPage() {
             onClick={() => {
               const ev = eventsData[0];
               const newStart = new Date(new Date(ev.startAt).getTime() + 60 * 60000);
-              const durationMin = Math.max(1, Math.round((new Date(ev.endAt).getTime() - new Date(ev.startAt).getTime()) / 60000));
+              const durationMin = calculateDurationMinutes(ev.startAt, ev.endAt);
               const newEnd = new Date(newStart.getTime() + durationMin * 60000);
               moveWithPrefs({ eventId: ev.id, startAt: newStart, endAt: newEnd });
             }}
@@ -387,7 +388,7 @@ export default function CalendarPage() {
             onMoveEvent={(eventId, startAt) => {
               const ev = eventsData.find((e) => e.id === eventId);
               if (!ev) return;
-              const durationMin = Math.max(1, Math.round((new Date(ev.endAt).getTime() - new Date(ev.startAt).getTime()) / 60000));
+              const durationMin = calculateDurationMinutes(ev.startAt, ev.endAt);
               const endAt = new Date(startAt.getTime() + durationMin * 60000);
               moveWithPrefs({ eventId, startAt, endAt });
             }}

--- a/src/components/calendar/CalendarGrid.tsx
+++ b/src/components/calendar/CalendarGrid.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React from 'react';
 import { useDraggable, useDroppable, useDndMonitor } from '@dnd-kit/core';
+import { calculateDurationMinutes } from '@/lib/datetime';
 
 type ViewMode = 'day' | 'week' | 'month';
 
@@ -174,7 +175,7 @@ export function CalendarGrid(props: {
               const startMin = s.getHours() * 60 + s.getMinutes();
               const windowStartMin = startHour * 60;
               const topMin = Math.max(0, startMin - windowStartMin);
-              const durMin = Math.max(1, Math.round((ed.getTime() - s.getTime()) / 60000));
+              const durMin = calculateDurationMinutes(s, ed);
               const pxPerMin = rowPx / 60;
               const topPx = topMin * pxPerMin;
               const heightPx = Math.max(12, durMin * pxPerMin);

--- a/src/lib/datetime.test.ts
+++ b/src/lib/datetime.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatLocalDateTime, parseLocalDateTime } from './datetime';
+import { formatLocalDateTime, parseLocalDateTime, calculateDurationMinutes } from './datetime';
 
 describe('datetime utility', () => {
   it('round trips preserving local timezone', () => {
@@ -18,5 +18,15 @@ describe('datetime utility', () => {
     expect(parsed.getTime()).toBe(date.getTime());
 
     process.env.TZ = originalTZ;
+  });
+
+  it('calculates duration minutes with minimum of one minute', () => {
+    const start = new Date(2024, 0, 1, 9, 0);
+    const end = new Date(2024, 0, 1, 10, 30);
+    expect(calculateDurationMinutes(start, end)).toBe(90);
+    expect(calculateDurationMinutes(start, start)).toBe(1);
+    expect(
+      calculateDurationMinutes(start.toISOString(), end.toISOString())
+    ).toBe(90);
   });
 });

--- a/src/lib/datetime.ts
+++ b/src/lib/datetime.ts
@@ -20,6 +20,12 @@ export function parseLocalDateTime(value: string): Date {
   return new Date(y, (m || 1) - 1, d || 1, hh || 0, mm || 0, 0, 0);
 }
 
+export function calculateDurationMinutes(startAt: Date | string, endAt: Date | string): number {
+  const start = new Date(startAt);
+  const end = new Date(endAt);
+  return Math.max(1, Math.round((end.getTime() - start.getTime()) / 60000));
+}
+
 export function defaultEndOfToday(): string {
   const d = new Date();
   d.setHours(23, 59, 0, 0);


### PR DESCRIPTION
## Summary
- add calculateDurationMinutes helper
- use calculateDurationMinutes to replace inline Math.max duration logic
- test duration helper

## Testing
- `npm run lint`
- `CI=true npm test` *(fails: api.task.list.useQuery is not a function)*
- `npm run build` *(fails: Property 'onPendingChange' is missing in type ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b657268c108320ba098816d7eea6a7