### PR TITLE
feat: improve backlog accessibility

### DIFF
--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -28,7 +28,7 @@ test.describe('calendar', () => {
 
     await page.goto('/calendar');
 
-    const task = page.getByRole('button', { name: new RegExp(`focus ${title}`, 'i') });
+    const task = page.getByRole('button', { name: new RegExp(`${title}`, 'i') });
     const targetCell = page.locator('[id^="cell-"]').first();
 
     const taskBox = await task.boundingBox();
@@ -94,7 +94,7 @@ test.describe('calendar', () => {
 
     await page.goto('/calendar');
 
-    const task = page.getByRole('button', { name: new RegExp(`focus ${title}`, 'i') });
+    const task = page.getByRole('button', { name: new RegExp(`${title}`, 'i') });
     const targetCell = page.locator('[id^="cell-"]').first();
 
     const taskBox = await task.boundingBox();
@@ -123,7 +123,7 @@ test.describe('calendar', () => {
 
     await page.goto('/calendar');
 
-    const backlogItem = page.getByRole('button', { name: new RegExp(`focus ${title}`, 'i') });
+    const backlogItem = page.getByRole('button', { name: new RegExp(`${title}`, 'i') });
     await backlogItem.focus();
     await page.keyboard.press(' ');
 

--- a/src/app/calendar/page.test.tsx
+++ b/src/app/calendar/page.test.tsx
@@ -106,7 +106,7 @@ describe('CalendarPage', () => {
 
   it('focus mode toggles on with Space on a task', () => {
     render(<CalendarPage />);
-    const backlogItem = screen.getByRole('button', { name: /focus Unscheduled task/i });
+    const backlogItem = screen.getByRole('button', { name: /Unscheduled task/i });
 
     backlogItem.focus();
     fireEvent.keyDown(backlogItem, { key: ' ' });

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -340,11 +340,22 @@ export default function CalendarPage() {
       <div className="w-full space-y-3 self-start md:col-span-1">
         <h2 className="font-semibold">Backlog</h2>
         <ul className="space-y-2">
-          {backlog.map((t) => (
-            <li key={t.id}>
-              <DraggableTask id={t.id} title={t.title} onSpaceKey={() => toggleFocus(t.id)} />
-            </li>
-          ))}
+          {backlog.map((t) => {
+            const labelId = `backlog-task-${t.id}-label`;
+            const descId = t.notes ? `backlog-task-${t.id}-desc` : undefined;
+            return (
+              <li key={t.id}>
+                <DraggableTask
+                  id={t.id}
+                  title={t.title}
+                  onSpaceKey={() => toggleFocus(t.id)}
+                  labelId={labelId}
+                  description={t.notes ?? undefined}
+                  descriptionId={descId}
+                />
+              </li>
+            );
+          })}
         </ul>
 
         {/* Test-only helper to simulate a drop action */}

--- a/src/components/calendar/CalendarGrid.tsx
+++ b/src/components/calendar/CalendarGrid.tsx
@@ -227,9 +227,24 @@ function GridCell({ day, hour }: { day: Date; hour: number }) {
   );
 }
 
-export function DraggableTask({ id, title, onSpaceKey }: { id: string; title: string; onSpaceKey?: () => void }) {
+export function DraggableTask({
+  id,
+  title,
+  onSpaceKey,
+  labelId,
+  description,
+  descriptionId,
+}: {
+  id: string;
+  title: string;
+  onSpaceKey?: () => void;
+  labelId?: string;
+  description?: string;
+  descriptionId?: string;
+}) {
   const { attributes, listeners, setNodeRef, transform } = useDraggable({ id: `task-${id}` });
   const style: React.CSSProperties = transform ? { transform: `translate3d(${transform.x}px, ${transform.y}px, 0)` } : {};
+  const descId = description ? descriptionId ?? `${id}-desc` : undefined;
   return (
     <button
       ref={setNodeRef}
@@ -237,7 +252,8 @@ export function DraggableTask({ id, title, onSpaceKey }: { id: string; title: st
       {...listeners}
       className="w-full text-left px-2 py-1 rounded border"
       style={style}
-      aria-label={`focus ${title}`}
+      aria-labelledby={labelId}
+      aria-describedby={descId}
       data-task-id={id}
       onKeyDown={(e) => {
         if (e.key === ' ' || e.key === 'Spacebar' || e.key === 'Space') {
@@ -267,7 +283,12 @@ export function DraggableTask({ id, title, onSpaceKey }: { id: string; title: st
         onSpaceKey?.();
       }}
     >
-      {title}
+      <span id={labelId}>{title}</span>
+      {description && (
+        <span id={descId} className="sr-only">
+          {description}
+        </span>
+      )}
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- ensure backlog tasks expose accessible labels and descriptions
- update tests for new task accessible names

## Testing
- `npm run lint`
- `CI=true npm test` *(fails: onPendingChange is not a function)*
- `CI=true npm run build` *(fails: Property 'onPendingChange' is missing)*
- `npx playwright test e2e/calendar.spec.ts` *(fails: browserType.launch: Executable doesn't exist)*


------
https://chatgpt.com/codex/tasks/task_e_68b6572a39708320873a8d46b29f25f9