### PR TITLE
feat: make focus timer accessible

### DIFF
--- a/src/app/calendar/page.test.tsx
+++ b/src/app/calendar/page.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import React from 'react';
-import { render, screen, fireEvent, within } from '@testing-library/react';
+import { render, screen, fireEvent, within, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as matchers from '@testing-library/jest-dom/matchers';
 expect.extend(matchers);
@@ -112,6 +112,25 @@ describe('CalendarPage', () => {
     fireEvent.keyDown(backlogItem, { key: ' ' });
     expect(focusStart).toHaveBeenCalledWith({ taskId: 't1' });
     expect(screen.getByText(/Focusing:/i)).toBeInTheDocument();
+  });
+
+  it('announces elapsed focus time updates', () => {
+    vi.useFakeTimers();
+    render(<CalendarPage />);
+
+    const backlogItem = screen.getByRole('button', { name: /focus Unscheduled task/i });
+    backlogItem.focus();
+    fireEvent.keyDown(backlogItem, { key: ' ' });
+
+    const timer = screen.getByRole('timer', { name: /elapsed focus time/i });
+    expect(timer).toHaveAttribute('aria-live', 'polite');
+    expect(timer).toHaveTextContent('0s');
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(timer).toHaveTextContent('2s');
+    vi.useRealTimers();
   });
 
   it('schedules an unscheduled task with default 30 minutes when dropped onto calendar', () => {

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -222,7 +222,13 @@ export default function CalendarPage() {
         {ViewTabs}
         <section className="p-4 rounded border">
           <h2 className="text-xl font-semibold">Focusing: {task?.title}</h2>
-          <p aria-label="timer">{Math.floor(elapsed / 1000)}s</p>
+          <p
+            role="timer"
+            aria-live="polite"
+            aria-label="Elapsed focus time"
+          >
+            {Math.floor(elapsed / 1000)}s
+          </p>
           <button className="mt-2 px-3 py-1 border rounded" onClick={() => toggleFocus(focusedTaskId!)}>Unfocus</button>
         </section>
       </main>


### PR DESCRIPTION
## Summary
- improve focus timer accessibility with ARIA attributes
- test timer announces elapsed focus time updates

## Testing
- `npm run lint`
- `CI=true npm test src/app/calendar/page.test.tsx`
- `npm run build` *(fails: Property 'onPendingChange' is missing in type in src/app/courses/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b6573c8f708320859f4d0ca10441dc