### PR TITLE
feat: virtualize calendar backlog list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-hot-toast": "^2.5.2",
+        "react-window": "^1.8.11",
         "recharts": "^2.15.4",
         "superjson": "^2.2.1",
         "zod": "^3.23.8"
@@ -45,6 +46,7 @@
         "@types/node": "^20.12.12",
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
+        "@types/react-window": "^1.8.8",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",
         "autoprefixer": "^10.4.19",
@@ -1222,6 +1224,16 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-window": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.8.tgz",
+      "integrity": "sha512-8Ls660bHR1AUA2kuRvVG9D/4XpRC6wjAaPT9dil7Ckc76eP9TKWZwwmgfq8Q1LANX3QNDnoU4Zp48A3w+zK69Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -4963,6 +4975,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "dev": true,
@@ -5985,6 +6003,23 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-hot-toast": "^2.5.2",
+    "react-window": "^1.8.11",
     "recharts": "^2.15.4",
     "superjson": "^2.2.1",
     "zod": "^3.23.8"
@@ -54,6 +55,7 @@
     "@types/node": "^20.12.12",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
+    "@types/react-window": "^1.8.8",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
     "autoprefixer": "^10.4.19",

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { DndContext, type DragEndEvent, MouseSensor, TouchSensor, useSensor, useSensors, closestCorners } from '@dnd-kit/core';
+import { FixedSizeList as List } from 'react-window';
 import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { api } from '@/server/api/react';
@@ -59,6 +60,8 @@ export default function CalendarPage() {
     const scheduledTaskIds = new Set(eventsData.map((e) => e.taskId));
     return tasksData.filter((t) => !scheduledTaskIds.has(t.id));
   }, [tasksData, eventsData]);
+
+  const ITEM_SIZE = 48;
 
   useEffect(() => {
     if (eventsData?.[0]?.startAt) {
@@ -339,13 +342,26 @@ export default function CalendarPage() {
       >
       <div className="w-full space-y-3 self-start md:col-span-1">
         <h2 className="font-semibold">Backlog</h2>
-        <ul className="space-y-2">
-          {backlog.map((t) => (
-            <li key={t.id}>
-              <DraggableTask id={t.id} title={t.title} onSpaceKey={() => toggleFocus(t.id)} />
-            </li>
-          ))}
-        </ul>
+        <List
+          height={Math.min(400, backlog.length * ITEM_SIZE)}
+          itemCount={backlog.length}
+          itemSize={ITEM_SIZE}
+          width="100%"
+          itemKey={(index) => backlog[index].id}
+        >
+          {({ index, style }) => {
+            const t = backlog[index];
+            return (
+              <div style={{ ...style, paddingBottom: 8 }}>
+                <DraggableTask
+                  id={t.id}
+                  title={t.title}
+                  onSpaceKey={() => toggleFocus(t.id)}
+                />
+              </div>
+            );
+          }}
+        </List>
 
         {/* Test-only helper to simulate a drop action */}
         {backlog[0] && (

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -214,10 +214,10 @@ export default function CoursesPage() {
 
 function CourseItem({
   course,
-  onPendingChange,
+  onPendingChange = () => {},
 }: {
   course: { id: string; title: string; term: string | null; color: string | null };
-  onPendingChange: (id: string, pending: boolean) => void;
+  onPendingChange?: (id: string, pending: boolean) => void;
 }) {
   const utils = api.useUtils();
   const {


### PR DESCRIPTION
## Summary
- install `react-window` for list virtualization
- render calendar backlog with `FixedSizeList` while keeping drag-and-drop
- relax required `onPendingChange` prop in course items

## Testing
- `npm run lint`
- `CI=true npm test src/app/calendar/page.test.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6573fbb948320b1cdcf864166d045