### PR TITLE
feat: redesign courses page

### DIFF
--- a/src/app/courses/page.test.tsx
+++ b/src/app/courses/page.test.tsx
@@ -1,300 +1,88 @@
 // @vitest-environment jsdom
 import React from 'react';
-import { render, screen, fireEvent, within, act } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, within, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest';
 import * as matchers from '@testing-library/jest-dom/matchers';
 expect.extend(matchers);
 
-vi.mock('@/lib/toast', () => ({ toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() } }));
-import { toast } from '@/lib/toast';
 import CoursesPage from './page';
 
-const { listMock, createMock, updateMock, deleteMock, deleteManyMock } = vi.hoisted(
-  () => ({
-    listMock: vi.fn(),
-    createMock: vi.fn(),
-    updateMock: vi.fn(),
-    deleteMock: vi.fn(),
-    deleteManyMock: vi.fn(),
-  }),
-);
+vi.mock('@/lib/toast', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
-vi.mock('@/server/api/react', () => ({
-  api: {
-    useUtils: () => ({ course: { list: { invalidate: vi.fn() } } }),
-    course: {
-      list: { useQuery: listMock },
-      create: { useMutation: createMock },
-      update: { useMutation: updateMock },
-      delete: { useMutation: deleteMock },
-      deleteMany: { useMutation: deleteManyMock },
+const createMock = vi.fn();
+const updateMock = vi.fn();
+const deleteMock = vi.fn();
+let listData: Array<{ id: string; title: string; term: string | null; color: string | null; createdAt?: string }> = [];
+let createIsPending = false;
+let updateIsPending = false;
+let deleteIsPending = false;
+
+vi.mock('@/server/api/react', async () => {
+  const actual = await vi.importActual<any>('@/server/api/react');
+  return {
+    api: {
+      ...actual.api,
+      useUtils: () => ({ course: { list: { invalidate: vi.fn() } } }),
+      course: {
+        list: { useQuery: () => ({ data: listData }) },
+        create: { useMutation: () => ({ mutate: createMock, isPending: createIsPending }) },
+        update: { useMutation: () => ({ mutate: updateMock, isPending: updateIsPending }) },
+        delete: { useMutation: () => ({ mutate: deleteMock, isPending: deleteIsPending }) },
+      },
     },
-  },
-}));
+  };
+});
+
+beforeEach(() => {
+  createMock.mockReset();
+  updateMock.mockReset();
+  deleteMock.mockReset();
+  listData = [];
+  createIsPending = false;
+  updateIsPending = false;
+  deleteIsPending = false;
+});
+afterEach(() => cleanup());
+afterAll(() => vi.resetModules());
 
 describe('CoursesPage', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    deleteManyMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
-  });
-
-  it('renders loading state', () => {
-    listMock.mockReturnValue({ data: [], isLoading: true, error: undefined });
-    createMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
+  it('shows empty state message when no courses', () => {
     render(<CoursesPage />);
-    const list = screen.getByLabelText('Loading courses');
-    expect(within(list).getAllByRole('listitem')).toHaveLength(4);
+    expect(screen.getByText('No courses yet.')).toBeInTheDocument();
   });
 
-  it('shows error message', () => {
-    listMock.mockReturnValue({ data: [], isLoading: false, error: { message: 'Failed' } });
-    createMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
-    render(<CoursesPage />);
-    expect(screen.getByText('Failed')).toBeInTheDocument();
-  });
-
-  it('displays course count in heading', () => {
-    listMock.mockReturnValue({
-      data: [
-        { id: '1', title: 'Math', term: null, color: null },
-        { id: '2', title: 'History', term: null, color: null },
-      ],
-      isLoading: false,
-      error: undefined,
-    });
-    createMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
-    render(<CoursesPage />);
-    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Courses (2)');
-  });
-
-    it('disables add button and shows create error', () => {
-      listMock.mockReturnValue({ data: [], isLoading: false, error: undefined });
-      createMock.mockReturnValue({ mutate: vi.fn(), isPending: true, error: { message: 'Create failed' } });
-      render(<CoursesPage />);
-      expect(screen.getByRole('button', { name: /add course/i })).toBeDisabled();
-      expect(screen.getByText('Create failed')).toBeInTheDocument();
-    });
-
-  it('disables save and delete buttons and shows errors', () => {
-    listMock.mockReturnValue({
-      data: [{ id: '1', title: 'Course', term: null, color: null, nextDueAt: null }],
-      isLoading: false,
-      error: undefined,
-    });
-    createMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
-    updateMock.mockReturnValue({ mutate: vi.fn(), isPending: true, error: { message: 'Update failed' } });
-    deleteMock.mockReturnValue({ mutate: vi.fn(), isPending: true, error: { message: 'Delete failed' } });
-    deleteManyMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
-    render(<CoursesPage />);
-    const item = screen.getAllByRole('listitem')[0];
-    expect(within(item).getByRole('button', { name: /save/i })).toBeDisabled();
-    expect(within(item).getByRole('button', { name: /delete/i })).toBeDisabled();
-    expect(screen.getByText('Update failed')).toBeInTheDocument();
-    expect(screen.getByText('Delete failed')).toBeInTheDocument();
-  });
-
-  it('shows error toast when course title exists', () => {
-    listMock.mockReturnValue({
-      data: [{ id: '1', title: 'Math', term: null, color: null, nextDueAt: null }],
-      isLoading: false,
-      error: undefined,
-    });
-    const mutate = vi.fn();
-    createMock.mockReturnValue({ mutate, isPending: false, error: undefined });
-    render(<CoursesPage />);
-    fireEvent.change(screen.getByPlaceholderText('Course title'), {
-      target: { value: 'Math' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: /add course/i }));
-    expect(mutate).not.toHaveBeenCalled();
-    expect(toast.error).toHaveBeenCalledWith('Course already exists.');
-  });
-
-  it('shows swatch preview when color changes', () => {
-    listMock.mockReturnValue({ data: [], isLoading: false, error: undefined });
-    createMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
-    render(<CoursesPage />);
-    const preview = screen.getByTestId('color-preview');
-    expect(preview).toHaveStyle({ backgroundColor: '#000000' });
-    const swatch = screen.getByRole('button', { name: 'Select color #FF0000' });
-    fireEvent.click(swatch);
-    expect(preview).toHaveStyle({ backgroundColor: '#FF0000' });
-  });
-
-  it('sorts courses by title by default and toggles to term', () => {
-    const mockCourses = [
-      { id: '1', title: 'B', term: 'Summer', color: null, nextDueAt: null },
-      { id: '2', title: 'A', term: 'Winter', color: null, nextDueAt: null },
+  it('filters and sorts courses', () => {
+    listData = [
+      { id: '1', title: 'Alpha', term: 'Fall', color: null, createdAt: '2023-01-01T00:00:00Z' },
+      { id: '2', title: 'Beta', term: 'Spring', color: null, createdAt: '2023-02-01T00:00:00Z' },
     ];
-    listMock.mockReturnValue({ data: mockCourses, isLoading: false, error: undefined });
-    createMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
-    updateMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
-    deleteMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
-
     render(<CoursesPage />);
-    const items = screen.getAllByRole('listitem');
-    expect(within(items[0]).getAllByRole('textbox')[0]).toHaveValue('A');
-    fireEvent.click(screen.getByRole('button', { name: /sort by term/i }));
-    const itemsAfter = screen.getAllByRole('listitem');
-    expect(within(itemsAfter[0]).getAllByRole('textbox')[0]).toHaveValue('B');
+    const list = screen.getByRole('list');
+    const titles = within(list)
+      .getAllByRole('heading', { level: 2 })
+      .map((h) => h.textContent);
+    expect(titles).toEqual(['Beta', 'Alpha']);
+
+    const sortSelect = screen.getByRole('combobox', { name: /sort by/i });
+    fireEvent.change(sortSelect, { target: { value: 'title' } });
+    const titlesSorted = within(list)
+      .getAllByRole('heading', { level: 2 })
+      .map((h) => h.textContent);
+    expect(titlesSorted).toEqual(['Alpha', 'Beta']);
+
+    const searchInput = screen.getByPlaceholderText('Search courses...');
+    fireEvent.change(searchInput, { target: { value: 'Alpha' } });
+    const filtered = within(list)
+      .getAllByRole('heading', { level: 2 })
+      .map((h) => h.textContent);
+    expect(filtered).toEqual(['Alpha']);
   });
 
-  it('toggles sort direction', () => {
-    const mockCourses = [
-      { id: '1', title: 'A', term: 'Fall', color: null, nextDueAt: null },
-      { id: '2', title: 'B', term: 'Spring', color: null, nextDueAt: null },
-    ];
-    listMock.mockReturnValue({ data: mockCourses, isLoading: false, error: undefined });
-    createMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
-    updateMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
-    deleteMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
-
+  it('opens edit modal when clicking edit icon', () => {
+    listData = [{ id: '1', title: 'Math', term: null, color: null }];
     render(<CoursesPage />);
-    const items = screen.getAllByRole('listitem');
-    expect(within(items[0]).getAllByRole('textbox')[0]).toHaveValue('A');
-    fireEvent.click(screen.getByRole('button', { name: /sort by title/i }));
-    const itemsAfter = screen.getAllByRole('listitem');
-    expect(within(itemsAfter[0]).getAllByRole('textbox')[0]).toHaveValue('B');
-  });
-
-  it('filters courses by search input', () => {
-    vi.useFakeTimers();
-    listMock.mockReturnValue({
-      data: [
-        { id: '1', title: 'Math', term: 'Fall', color: '#ABCDEF', nextDueAt: null },
-        { id: '2', title: 'History', term: 'Spring', color: '#123456', nextDueAt: null },
-      ],
-      isLoading: false,
-      error: undefined,
-    });
-    createMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
-    updateMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
-    deleteMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
-
-    render(<CoursesPage />);
-
-    const input = screen.getByPlaceholderText('Search courses...');
-
-    // filter by title (case insensitive)
-    fireEvent.change(input, { target: { value: 'math' } });
-    act(() => {
-      vi.advanceTimersByTime(400);
-    });
-    expect(screen.getByDisplayValue('Math')).toBeInTheDocument();
-    expect(screen.queryByDisplayValue('History')).toBeNull();
-
-    // filter by term
-    fireEvent.change(input, { target: { value: 'SPRING' } });
-    act(() => {
-      vi.advanceTimersByTime(400);
-    });
-    expect(screen.getByDisplayValue('History')).toBeInTheDocument();
-    expect(screen.queryByDisplayValue('Math')).toBeNull();
-
-      // filter by color
-      fireEvent.change(input, { target: { value: '#abcdef' } });
-      act(() => {
-        vi.advanceTimersByTime(400);
-      });
-      expect(screen.getByDisplayValue('Math')).toBeInTheDocument();
-      expect(screen.queryByDisplayValue('History')).toBeNull();
-
-      // filter by description
-      fireEvent.change(input, { target: { value: 'world' } });
-      act(() => {
-        vi.advanceTimersByTime(400);
-      });
-      expect(screen.getByDisplayValue('History')).toBeInTheDocument();
-      expect(screen.queryByDisplayValue('Math')).toBeNull();
-
-      vi.useRealTimers();
-  });
-
-  it('filters courses by selected term', () => {
-    listMock.mockReturnValue({
-      data: [
-        { id: '1', title: 'Math', term: 'Fall', color: null, nextDueAt: null },
-        { id: '2', title: 'History', term: 'Spring', color: null, nextDueAt: null },
-      ],
-      isLoading: false,
-      error: undefined,
-    });
-    createMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
-    updateMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
-    deleteMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
-
-    render(<CoursesPage />);
-
-    const select = screen.getByLabelText('Filter by term');
-    fireEvent.change(select, { target: { value: 'Spring' } });
-
-    expect(screen.getByDisplayValue('History')).toBeInTheDocument();
-    expect(screen.queryByDisplayValue('Math')).toBeNull();
-  });
-
-  it('deletes selected courses', () => {
-    listMock.mockReturnValue({
-      data: [
-        { id: '1', title: 'Math', term: null, color: null },
-        { id: '2', title: 'History', term: null, color: null },
-      ],
-      isLoading: false,
-      error: undefined,
-    });
-    createMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
-    updateMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
-    deleteMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
-    const mutateMany = vi.fn();
-    deleteManyMock.mockReturnValue({ mutate: mutateMany, isPending: false, error: undefined });
-    vi.spyOn(window, 'confirm').mockReturnValue(true);
-
-    render(<CoursesPage />);
-
-    fireEvent.click(screen.getByLabelText('Select Math'));
-    fireEvent.click(screen.getByRole('button', { name: /delete selected/i }));
-
-    expect(mutateMany).toHaveBeenCalledWith({ ids: ['1'] });
-  });
-
-  it('shows message when no courses match search', () => {
-    vi.useFakeTimers();
-    listMock.mockReturnValue({
-      data: [{ id: '1', title: 'Math', term: 'Fall', color: '#ABCDEF' }],
-      isLoading: false,
-      error: undefined,
-    });
-    createMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
-    updateMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
-    deleteMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
-
-    render(<CoursesPage />);
-
-    const input = screen.getByPlaceholderText('Search courses...');
-    fireEvent.change(input, { target: { value: 'History' } });
-    act(() => {
-      vi.advanceTimersByTime(400);
-    });
-    expect(screen.getByText('No courses found')).toBeInTheDocument();
-    vi.useRealTimers();
-  });
-
-  it('confirms before deleting a course', () => {
-    listMock.mockReturnValue({
-      data: [{ id: '1', title: 'Course', term: null, color: null }],
-      isLoading: false,
-      error: undefined,
-    });
-    createMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
-    updateMock.mockReturnValue({ mutate: vi.fn(), isPending: false, error: undefined });
-    const mutate = vi.fn();
-    deleteMock.mockReturnValue({ mutate, isPending: false, error: undefined });
-
-    render(<CoursesPage />);
-
-    fireEvent.click(screen.getByRole('button', { name: /delete/i }));
-    const dialog = screen.getByRole('alertdialog');
-    expect(dialog).toBeInTheDocument();
-    fireEvent.click(within(dialog).getByRole('button', { name: /^delete$/i }));
-    expect(mutate).toHaveBeenCalledWith({ id: '1' });
+    fireEvent.click(screen.getByRole('button', { name: /edit course/i }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
 });
+

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -1,480 +1,120 @@
 "use client";
-import React, { useState, useEffect } from "react";
-import { ArrowUpDown as ArrowUpDownIcon } from "lucide-react";
+import React, { useState } from "react";
+import { useSession } from "next-auth/react";
+import { Pencil } from "lucide-react";
 import Link from "next/link";
+
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { AlertDialog } from "@/components/ui/alert-dialog";
-import { CourseSkeleton } from "@/components/CourseSkeleton";
+import CourseModal, { Course } from "@/components/course-modal";
 import { api } from "@/server/api/react";
-import { toast } from "@/lib/toast";
-import { TrashIcon, CheckIcon, CaretSortIcon } from "@radix-ui/react-icons";
-import { Alert } from "@/components/ui/alert";
-import { clsx } from "clsx";
-
-const COLOR_OPTIONS = [
-  "#000000",
-  "#FF0000",
-  "#00FF00",
-  "#0000FF",
-  "#FFFF00",
-  "#FF00FF",
-  "#00FFFF",
-];
 
 export default function CoursesPage() {
-  const utils = api.useUtils();
-  const [page, setPage] = useState(1);
-  const limit = 10;
-  const {
-    mutate: createCourse,
-    isPending: isCreating,
-    error: createError,
-  } = api.course.create.useMutation({
-    onSuccess: async () => {
-      await utils.course.list.invalidate();
-      toast.success("Course added.");
-    },
-    onError: (e) => toast.error(e.message || "Create failed."),
-  });
-  const [title, setTitle] = useState("");
-  const [term, setTerm] = useState("");
-  const [color, setColor] = useState("");
-  const [description, setDescription] = useState("");
-  const [sortBy, setSortBy] = useState<"title" | "term">("title");
-  const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
+  const { data: session } = useSession();
+  const { data: courses = [] } = api.course.list.useQuery(
+    { page: 1, limit: 100 },
+    { enabled: !!session }
+  );
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editing, setEditing] = useState<Course | null>(null);
   const [search, setSearch] = useState("");
-  const [debouncedSearch, setDebouncedSearch] = useState("");
-  const [termFilter, setTermFilter] = useState("");
-  const [selectedIds, setSelectedIds] = useState<string[]>([]);
-  const isAddDisabled = isCreating || title.trim() === "";
-  const handlePendingChange = () => {};
+  const [sort, setSort] = useState<"createdAt" | "title">("createdAt");
 
-  const {
-    mutate: deleteMany,
-    isPending: isDeletingMany,
-    error: deleteManyError,
-  } = api.course.deleteMany.useMutation({
-    onSuccess: async () => {
-      await utils.course.list.invalidate();
-      setSelectedIds([]);
-      toast.success("Courses deleted.");
-    },
-    onError: (e) => toast.error(e.message || "Delete failed."),
-  });
-
-  const toggleSelect = (id: string, checked: boolean) => {
-    setSelectedIds((prev) =>
-      checked ? [...prev, id] : prev.filter((x) => x !== id),
-    );
-  };
-
-  useEffect(() => {
-    const storedSortBy = localStorage.getItem("coursesSortBy");
-    const storedSortDir = localStorage.getItem("coursesSortDir");
-    const storedSearch = localStorage.getItem("coursesSearch");
-    const storedTermFilter = localStorage.getItem("coursesTermFilter");
-    if (storedSortBy === "title" || storedSortBy === "term") {
-      setSortBy(storedSortBy);
-    }
-    if (storedSortDir === "asc" || storedSortDir === "desc") {
-      setSortDir(storedSortDir);
-    }
-    if (storedSearch) {
-      setSearch(storedSearch);
-      setDebouncedSearch(storedSearch);
-    }
-    if (storedTermFilter) {
-      setTermFilter(storedTermFilter);
-    }
-  }, []);
-
-  useEffect(() => {
-    localStorage.setItem("coursesSortBy", sortBy);
-  }, [sortBy]);
-
-  useEffect(() => {
-    localStorage.setItem("coursesSortDir", sortDir);
-  }, [sortDir]);
-
-  useEffect(() => {
-    localStorage.setItem("coursesSearch", search);
-  }, [search]);
-
-  useEffect(() => {
-    localStorage.setItem("coursesTermFilter", termFilter);
-  }, [termFilter]);
-
-  useEffect(() => {
-    const t = setTimeout(() => setDebouncedSearch(search), 300);
-    return () => clearTimeout(t);
-  }, [search]);
-
-  if (isLoading)
-    return (
-      <ul aria-label="Loading courses" className="space-y-4">
-        {Array.from({ length: 4 }).map((_, i) => (
-          <CourseSkeleton
-            // eslint-disable-next-line react/no-array-index-key
-            key={i}
-          />
-        ))}
-      </ul>
-    );
-  if (error) return <p className="text-red-500">{error.message}</p>;
-  const courseCount = courses.length;
-
-  const sortedCourses = [...courses].sort((a, b) =>
-    sortBy === "title"
-      ? a.title.localeCompare(b.title)
-      : (a.term ?? "").localeCompare(b.term ?? "") ||
-        a.title.localeCompare(b.title),
-  );
-  if (sortDir === "desc") sortedCourses.reverse();
-
-  const terms = Array.from(
-    new Set(
-      courses
-        .map((c) => c.term)
-        .filter((t): t is string => Boolean(t)),
-    ),
-  );
-
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const t = title.trim();
-    if (!t) return;
-    if (courses.some((c) => c.title === t)) {
-      toast.error("Course already exists.");
-      return;
-    }
-    createCourse({
-      title: t,
-      term: term.trim() || undefined,
-      color: color.trim() || undefined,
-      description: description.trim() || undefined,
+  const displayed = [...courses]
+    .filter((c) => c.title.toLowerCase().includes(search.toLowerCase()))
+    .sort((a, b) => {
+      if (sort === "title") return a.title.localeCompare(b.title);
+      return (
+        new Date((b as any).createdAt ?? 0).getTime() -
+        new Date((a as any).createdAt ?? 0).getTime()
+      );
     });
-    setTitle("");
-    setTerm("");
-    setColor("");
-    setDescription("");
-  };
-
-  const query = debouncedSearch.toLowerCase();
-  const filteredCourses = sortedCourses.filter((c) => {
-    const q = query;
-    const matches =
-      c.title.toLowerCase().includes(q) ||
-      (c.term ?? "").toLowerCase().includes(q) ||
-      (c.color ?? "").toLowerCase().includes(q);
-    return matches && (termFilter === "" || c.term === termFilter);
-  });
-  
 
   return (
-    <div className="container mx-auto px-4">
-      <main className="space-y-6 md:grid md:grid-cols-2 md:gap-6 md:space-y-0">
-        <h1 className="text-2xl font-semibold md:col-span-2">Courses</h1>
-        <div className="max-w-md mx-auto md:mx-0 rounded-lg border p-4 shadow-sm bg-card">
-          <form onSubmit={handleSubmit} className="flex flex-col gap-2">
-            <label htmlFor="course-title" className="flex flex-col gap-1">
-              Course title
-              <Input
-                id="course-title"
-                placeholder="Course title"
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-              />
-            </label>
-            <label htmlFor="course-term" className="flex flex-col gap-1">
-              Term (optional)
-              <Input
-                id="course-term"
-                placeholder="Term (optional)"
-                value={term}
-                onChange={(e) => setTerm(e.target.value)}
-              />
-            </label>
-            <div className="flex flex-col gap-1">
-              <span>Color (optional)</span>
-              <div
-                role="group"
-                aria-label="Course color"
-                className="flex items-center gap-2"
-              >
-                <div className="flex flex-wrap gap-2">
-                  {COLOR_OPTIONS.map((c) => (
-                    <button
-                      key={c}
-                      type="button"
-                      aria-label={`Select color ${c}`}
-                      className={clsx(
-                        "h-10 w-10 rounded border border-black/10 p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10",
-                        color === c && "ring-2 ring-indigo-500 ring-offset-2",
-                      )}
-                      style={{ backgroundColor: c }}
-                      onClick={() => setColor(color === c ? "" : c)}
-                    />
-                  ))}
-                </div>
-                <div
-                  data-testid="color-preview"
-                  className="h-6 w-6 rounded border border-black/10 dark:border-white/10"
-                  style={{ backgroundColor: color || "#000000" }}
-                />
-              </div>
-            </div>
-            <Button type="submit" disabled={isAddDisabled}>
-              Add Course
-            </Button>
-            {createError && (
-              <Alert variant="error">{createError.message}</Alert>
-            )}
-          </form>
+    <main className="max-w-4xl mx-auto px-4 py-6 space-y-6">
+      <h1 className="text-2xl font-semibold">Courses</h1>
+      <Button
+        onClick={() => {
+          setEditing(null);
+          setModalOpen(true);
+        }}
+        className="self-start"
+      >
+        + Add Course
+      </Button>
+      <div className="rounded-xl border bg-white dark:bg-zinc-900 shadow-sm p-4 space-y-3 max-w-md">
+        <div className="flex items-center gap-2">
+          <Input
+            className="w-40 md:w-80"
+            placeholder="Search courses..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+          <select
+            aria-label="Sort by"
+            className="h-9 rounded-md border border-black/10 bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
+            value={sort}
+            onChange={(e) => setSort(e.target.value as "createdAt" | "title")}
+          >
+            <option value="createdAt">Creation date</option>
+            <option value="title">Title</option>
+          </select>
         </div>
-        <div className="space-y-4">
-          <div className="flex gap-2">
-            <Button
-              variant={sortBy === "title" ? "primary" : "secondary"}
-              onClick={() => setSortBy("title")}
-            >
-              Sort by Title
-            </Button>
-            <Button
-              variant={sortBy === "term" ? "primary" : "secondary"}
-              onClick={() => setSortBy("term")}
-            >
-              Sort by Term
-            </Button>
-            <Button
-              variant="tertiary"
-              onClick={() => setSortDir(sortDir === "asc" ? "desc" : "asc")}
-              aria-label="Toggle sort direction"
-            >
-              <ArrowUpDownIcon className="h-4 w-4" />
-            </Button>
-          </div>
-          <div className="max-w-md">
-            <div className="mb-4">
-              <label htmlFor="term-filter" className="mb-2 block">
-                Filter by term
-              </label>
-              <select
-                id="term-filter"
-                className="w-full rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
-                value={termFilter}
-                onChange={(e) => setTermFilter(e.target.value)}
-              >
-                <option value="">All terms</option>
-                {terms.map((t) => (
-                  <option key={t} value={t}>
-                    {t}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <input
-              className="mb-4 w-full rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
-              placeholder="Search courses..."
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-            />
-            <ul className="space-y-4">
-              {filteredCourses.length > 0 ? (
-                filteredCourses.map((c) => (
-                  <CourseItem
-                    key={c.id}
-                    course={c}
-                    onPendingChange={() => {}}
-                    selected={selectedIds.includes(c.id)}
-                    onSelect={toggleSelect}
-                  />
-                ))
-              ) : (
-                <li>No courses found</li>
-              )}
-            </ul>
-          </div>
-          
-          <div className="mb-4 flex justify-end">
-            <Button
-              variant="danger"
-              disabled={selectedIds.length === 0 || isDeletingMany}
-              onClick={() => {
-                if (window.confirm("Delete selected courses?")) {
-                  deleteMany({ ids: selectedIds });
-                }
+      </div>
+      {courses.length === 0 ? (
+        <p>No courses yet.</p>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3" role="list">
+          {displayed.map((c) => (
+            <CourseTile
+              key={c.id}
+              course={c as Course}
+              onEdit={(course) => {
+                setEditing(course);
+                setModalOpen(true);
               }}
-            >
-              <TrashIcon className="mr-2 h-4 w-4" />
-              Delete Selected
-            </Button>
-          </div>
-          {deleteManyError && (
-            <p className="mb-4 text-red-500">{deleteManyError.message}</p>
-          )}
-          
+            />
+          ))}
         </div>
-      </main>
+      )}
+      <CourseModal
+        open={modalOpen}
+        mode={editing ? "edit" : "create"}
+        course={editing ?? undefined}
+        onClose={() => {
+          setModalOpen(false);
+          setEditing(null);
+        }}
+      />
+    </main>
+  );
+}
+
+type CourseTileProps = { course: Course; onEdit: (c: Course) => void };
+
+function CourseTile({ course, onEdit }: CourseTileProps) {
+  return (
+    <div
+      role="listitem"
+      className="flex h-full flex-col justify-between rounded-xl border shadow-sm p-4"
+    >
+      <Link href={`/courses/${course.id}`} className="flex-1">
+        <h2 className="font-medium">{course.title}</h2>
+        {course.term && (
+          <p className="text-sm text-muted-foreground">{course.term}</p>
+        )}
+      </Link>
+      <div className="flex justify-end">
+        <button
+          type="button"
+          aria-label="Edit course"
+          className="p-1 text-neutral-400 hover:text-neutral-700"
+          onClick={() => onEdit(course)}
+        >
+          <Pencil className="h-4 w-4" />
+        </button>
+      </div>
     </div>
   );
 }
 
-export function CourseItem({
-  course,
-  onPendingChange,
-  selected,
-  onSelect,
-}: {
-  course: { id: string; title: string; term: string | null; color: string | null };
-  onPendingChange: (id: string, pending: boolean) => void;
-  selected: boolean;
-  onSelect: (id: string, checked: boolean) => void;
-}) {
-  const utils = api.useUtils();
-  const {
-    mutate: updateCourse,
-    isPending: isUpdating,
-    error: updateError,
-  } = api.course.update.useMutation({
-    onSuccess: async () => {
-      await utils.course.list.invalidate();
-      toast.success("Course updated.");
-    },
-    onError: (e) => toast.error(e.message || "Update failed."),
-  });
-  const {
-    mutate: deleteCourse,
-    isPending: isDeleting,
-    error: deleteError,
-  } = api.course.delete.useMutation({
-    onSuccess: async () => {
-      await utils.course.list.invalidate();
-      toast.success("Course deleted.");
-    },
-    onError: (e) => toast.error(e.message || "Delete failed."),
-  });
-  const [title, setTitle] = useState(course.title);
-  const [term, setTerm] = useState(course.term ?? "");
-  const [color, setColor] = useState(course.color ?? "");
-  const [description, setDescription] = useState(course.description ?? "");
-  const [hasPendingChanges, setHasPendingChanges] = useState(false);
-  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
-  const titleId = `course-${course.id}-title`;
-  const termId = `course-${course.id}-term`;
-  const colorId = `course-${course.id}-color`;
-  const descriptionId = `course-${course.id}-description`;
-  const trimmedTitle = title.trim();
-  const trimmedTerm = term.trim();
-  const trimmedColor = color.trim();
-  const trimmedDescription = description.trim();
-  const hasChanges =
-    trimmedTitle !== course.title ||
-    trimmedTerm !== (course.term ?? "") ||
-    trimmedColor !== (course.color ?? "") ||
-    trimmedDescription !== (course.description ?? "");
-
-  useEffect(() => {
-    setHasPendingChanges(hasChanges);
-    onPendingChange(course.id, hasChanges);
-  }, [course.id, hasChanges, onPendingChange]);
-
-  useEffect(() => {
-    return () => {
-      onPendingChange(course.id, false);
-    };
-  }, [course.id, onPendingChange]);
-
-  const isSaveDisabled = isUpdating || !hasPendingChanges;
-  return (
-    <li>
-      <div className="flex items-start gap-2">
-        <input
-          type="checkbox"
-          aria-label={`Select ${course.title}`}
-          className="mt-2"
-          checked={selected}
-          onChange={(e) => onSelect(course.id, e.target.checked)}
-        />
-        <div className="flex flex-col gap-2 rounded-lg border p-4 shadow-sm bg-card flex-1">
-          <label htmlFor={titleId} className="flex flex-col gap-1">
-            <span className="flex items-center gap-2">
-              Title
-              <span
-                className="h-4 w-4 rounded-full"
-                style={{ backgroundColor: color || "#000" }}
-              />
-            </span>
-            <input
-              id={titleId}
-              className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-            />
-          </label>
-          <label htmlFor={termId} className="flex flex-col gap-1">
-            Term
-            <input
-              id={termId}
-              className="rounded border border-black/10 bg-transparent px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
-              value={term}
-              onChange={(e) => setTerm(e.target.value)}
-            />
-          </label>
-          <label htmlFor={colorId} className="flex flex-col gap-1">
-            Color
-            <div className="flex items-center gap-2">
-              <input
-                id={colorId}
-                type="color"
-                aria-label="Course color"
-                className="h-10 w-10 rounded border border-black/10 bg-transparent p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
-                value={color || "#000000"}
-                onChange={(e) => setColor(e.target.value)}
-              />
-              <div
-                className="h-6 w-6 rounded border border-black/10 dark:border-white/10"
-                style={{ backgroundColor: color || "#000000" }}
-              />
-            </div>
-          </label>
-          <div className="flex gap-2">
-            <Button
-              disabled={isSaveDisabled}
-              onClick={() =>
-                updateCourse({
-                  id: course.id,
-                  title: trimmedTitle,
-                  term: trimmedTerm || null,
-                  color: trimmedColor || null,
-                })
-              }
-            >
-              Save
-            </Button>
-            <Button
-              variant="danger"
-              disabled={isDeleting}
-              onClick={() => setShowDeleteDialog(true)}
-            >
-              Delete
-            </Button>
-          </div>
-          <AlertDialog
-            open={showDeleteDialog}
-            title="Delete this course?"
-            onCancel={() => setShowDeleteDialog(false)}
-            onConfirm={() => {
-              deleteCourse({ id: course.id });
-              setShowDeleteDialog(false);
-            }}
-            confirmText="Delete"
-            confirmDisabled={isDeleting}
-          />
-          {updateError && <p className="text-red-500">{updateError.message}</p>}
-          {deleteError && <p className="text-red-500">{deleteError.message}</p>}
-        </div>
-      </div>
-    </li>
-  );
-}

--- a/src/components/course-modal.tsx
+++ b/src/components/course-modal.tsx
@@ -1,0 +1,213 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import { Modal } from "@/components/ui/modal";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { toast } from "@/lib/toast";
+import { api } from "@/server/api/react";
+import type { RouterOutputs } from "@/server/api/root";
+
+export type Course = RouterOutputs["course"]["list"][number];
+
+interface CourseModalProps {
+  open: boolean;
+  mode: "create" | "edit";
+  onClose: () => void;
+  course?: Course;
+}
+
+export function CourseModal({ open, mode, onClose, course }: CourseModalProps) {
+  const utils = api.useUtils();
+  const isEdit = mode === "edit";
+
+  const [title, setTitle] = useState("");
+  const [term, setTerm] = useState("");
+  const [color, setColor] = useState("#000000");
+  const [description, setDescription] = useState("");
+  const [titleError, setTitleError] = useState("");
+  const [termError, setTermError] = useState("");
+  const [descriptionError, setDescriptionError] = useState("");
+
+  useEffect(() => {
+    if (!open) return;
+    if (isEdit && course) {
+      setTitle(course.title);
+      setTerm(course.term ?? "");
+      setColor(course.color ?? "#000000");
+      setDescription(course.description ?? "");
+    } else {
+      setTitle("");
+      setTerm("");
+      setColor("#000000");
+      setDescription("");
+    }
+    setTitleError("");
+    setTermError("");
+    setDescriptionError("");
+  }, [open, isEdit, course]);
+
+  const create = api.course.create.useMutation({
+    onSuccess: () => {
+      toast.success("Saved!");
+      utils.course.list.invalidate();
+      onClose();
+    },
+    onError: (e) => toast.error(e.message || "Create failed."),
+  });
+
+  const update = api.course.update.useMutation({
+    onSuccess: () => {
+      toast.success("Saved!");
+      utils.course.list.invalidate();
+      onClose();
+    },
+    onError: (e) => toast.error(e.message || "Update failed."),
+  });
+
+  const del = api.course.delete.useMutation({
+    onSuccess: () => {
+      toast.success("Saved!");
+      utils.course.list.invalidate();
+      onClose();
+    },
+    onError: (e) => toast.error(e.message || "Delete failed."),
+  });
+
+  const handleSave = () => {
+    const t = title.trim();
+    const tm = term.trim();
+    const d = description.trim();
+    let hasError = false;
+    if (t.length < 1 || t.length > 200) {
+      setTitleError("Title must be between 1 and 200 characters.");
+      hasError = true;
+    }
+    if (tm.length > 100) {
+      setTermError("Term must be at most 100 characters.");
+      hasError = true;
+    }
+    if (d.length > 1000) {
+      setDescriptionError("Description must be at most 1000 characters.");
+      hasError = true;
+    }
+    if (hasError) return;
+    if (isEdit && course) {
+      update.mutate({
+        id: course.id,
+        title: t,
+        term: tm || null,
+        color: color || null,
+        description: d || null,
+      });
+    } else {
+      create.mutate({
+        title: t,
+        term: tm || undefined,
+        color: color || undefined,
+        description: d || undefined,
+      });
+    }
+  };
+
+  const footer = (
+    <>
+      {isEdit && course && (
+        <Button
+          variant="destructive"
+          className="mr-auto"
+          disabled={del.isPending}
+          onClick={() => {
+            if (window.confirm("Delete this course?")) {
+              del.mutate({ id: course.id });
+            }
+          }}
+        >
+          {del.isPending ? "Deleting..." : "Delete"}
+        </Button>
+      )}
+      <Button variant="tertiary" onClick={onClose}>
+        Cancel
+      </Button>
+      <Button disabled={create.isPending || update.isPending} onClick={handleSave}>
+        {create.isPending || update.isPending ? "Saving..." : "Save"}
+      </Button>
+    </>
+  );
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title={isEdit ? "Edit Course" : "New Course"}
+      footer={footer}
+    >
+      <div className="space-y-1">
+        <label htmlFor="course-title" className="text-sm font-medium">
+          Title
+        </label>
+        <Input
+          id="course-title"
+          placeholder="Course title"
+          value={title}
+          onChange={(e) => {
+            setTitle(e.target.value);
+            if (titleError) setTitleError("");
+          }}
+          error={titleError}
+        />
+        {titleError && <p className="text-sm text-red-500">{titleError}</p>}
+      </div>
+      <div className="space-y-1">
+        <label htmlFor="course-term" className="text-sm font-medium">
+          Term (optional)
+        </label>
+        <Input
+          id="course-term"
+          placeholder="Term (optional)"
+          value={term}
+          onChange={(e) => {
+            setTerm(e.target.value);
+            if (termError) setTermError("");
+          }}
+          error={termError}
+        />
+        {termError && <p className="text-sm text-red-500">{termError}</p>}
+      </div>
+      <div className="space-y-1">
+        <label htmlFor="course-color" className="text-sm font-medium">
+          Color (optional)
+        </label>
+        <input
+          id="course-color"
+          type="color"
+          className="h-10 w-10 rounded border border-black/10 bg-transparent p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-white/10"
+          value={color}
+          onChange={(e) => setColor(e.target.value)}
+        />
+      </div>
+      <div className="space-y-1">
+        <label htmlFor="course-description" className="text-sm font-medium">
+          Description (optional)
+        </label>
+        <Textarea
+          id="course-description"
+          placeholder="Description (optional)"
+          value={description}
+          onChange={(e) => {
+            setDescription(e.target.value);
+            if (descriptionError) setDescriptionError("");
+          }}
+          error={descriptionError}
+          rows={4}
+        />
+        {descriptionError && (
+          <p className="text-sm text-red-500">{descriptionError}</p>
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+export default CourseModal;
+


### PR DESCRIPTION
## Summary
- Display courses as cards with edit icon and link to detail view
- Add CourseModal component for creating and editing courses
- Update tests for new course page design

## Testing
- `npm run lint`
- `npx vitest run src/app/courses/page.test.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b752b7f3bc8320bcb51ddaffe69532