### PR TITLE
fix: enable task focus shortcut and button

### DIFF
--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -193,7 +193,7 @@ export default function CalendarPage() {
   // Global key handler to support Space toggling focus on a focused backlog task button
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === ' ') {
+      if (e.key === ' ' || e.key === 'Spacebar' || e.key === 'Space') {
         const el = document.activeElement as HTMLElement | null;
         const id = el?.getAttribute?.('data-task-id');
         if (id) {
@@ -406,7 +406,7 @@ export default function CalendarPage() {
             const labelId = `backlog-task-${t.id}-label`;
             const descId = t.notes ? `backlog-task-${t.id}-desc` : undefined;
             return (
-              <li key={t.id}>
+              <li key={t.id} className="flex items-center gap-2">
                 <DraggableTask
                   id={t.id}
                   title={t.title}
@@ -415,6 +415,14 @@ export default function CalendarPage() {
                   description={t.notes ?? undefined}
                   descriptionId={descId}
                 />
+                <button
+                  type="button"
+                  aria-label={`focus ${t.title}`}
+                  className="rounded border px-2 py-1 text-sm"
+                  onClick={() => toggleFocus(t.id)}
+                >
+                  Focus
+                </button>
               </li>
             );
           })}


### PR DESCRIPTION
## Summary
- handle `Space`/`Spacebar` key presses when toggling task focus
- add explicit Focus button next to backlog tasks
- cover keyboard and button interactions in calendar tests

## Testing
- `npm run lint`
- `npx vitest run src/app/calendar/page.test.tsx`
- `npm run build` *(fails: Cannot find name 'isLoading' in src/app/courses/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b756ae8b0c83209ffee7fd716d9bd7