### PR TITLE
feat: add chart legends and axis labels

### DIFF
--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -9,10 +9,11 @@ import {
   XAxis,
   YAxis,
   Tooltip,
+  Legend,
+  Label,
   PieChart,
   Pie,
   Cell,
-  ResponsiveContainer,
 } from "recharts";
 import { api } from "@/server/api/react";
 import type { RouterOutputs } from "@/server/api/root";
@@ -117,13 +118,27 @@ export default function StatsPage() {
               dataKey="status"
               stroke={chartColors.axis}
               tick={{ fill: chartColors.text }}
-            />
+            >
+              <Label
+                value="Status"
+                position="insideBottom"
+                fill={chartColors.text}
+              />
+            </XAxis>
             <YAxis
               allowDecimals={false}
               stroke={chartColors.axis}
               tick={{ fill: chartColors.text }}
-            />
+            >
+              <Label
+                value="Count"
+                angle={-90}
+                position="insideLeft"
+                fill={chartColors.text}
+              />
+            </YAxis>
             <Tooltip />
+            <Legend wrapperStyle={{ color: chartColors.text }} />
             <Bar dataKey="count" fill={chartColors.bar} />
           </BarChart>
         </section>
@@ -146,6 +161,7 @@ export default function StatsPage() {
               ))}
             </Pie>
             <Tooltip />
+            <Legend wrapperStyle={{ color: chartColors.text }} />
           </PieChart>
         </section>
         <section className="space-y-2">
@@ -162,13 +178,27 @@ export default function StatsPage() {
               dataKey="title"
               stroke={chartColors.axis}
               tick={{ fill: chartColors.text }}
-            />
+            >
+              <Label
+                value="Task"
+                position="insideBottom"
+                fill={chartColors.text}
+              />
+            </XAxis>
             <YAxis
               allowDecimals={false}
               stroke={chartColors.axis}
               tick={{ fill: chartColors.text }}
-            />
+            >
+              <Label
+                value="Minutes"
+                angle={-90}
+                position="insideLeft"
+                fill={chartColors.text}
+              />
+            </YAxis>
             <Tooltip />
+            <Legend wrapperStyle={{ color: chartColors.text }} />
             <Bar dataKey="minutes" fill={chartColors.bar} />
           </BarChart>
         </section>

--- a/src/test/recharts.mock.ts
+++ b/src/test/recharts.mock.ts
@@ -7,4 +7,6 @@ export const Tooltip = () => null;
 export const PieChart = (props: any) => React.createElement('div', props);
 export const Pie = () => null;
 export const Cell = () => null;
+export const Legend = () => null;
+export const Label = () => null;
 export const ResponsiveContainer = (props: any) => React.createElement('div', props);

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -83,6 +83,8 @@ vi.mock('recharts', () => {
     XAxis: Null,
     YAxis: Null,
     Tooltip: Null,
+    Legend: Null,
+    Label: Null,
     PieChart: Div,
     Pie: Null,
     Cell: Null,


### PR DESCRIPTION
## Summary
- show legends on stats bar and pie charts
- label chart axes with theme-aware colors
- update test mocks for recharts

## Testing
- `npm run lint`
- `npm test src/app/stats/page.test.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b75a6999e483208c622e1d13daa6ce