### PR TITLE
feat: color status bars in stats page

### DIFF
--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -49,7 +49,12 @@ export default function StatsPage() {
     () => ({
       text: isDark ? "#ffffff" : "#000000",
       axis: isDark ? "#ffffff" : "#000000",
-      bar: isDark ? "#34d399" : "#8884d8",
+      bar: {
+        TODO: isDark ? "#60a5fa" : "#8884d8",
+        IN_PROGRESS: isDark ? "#fbbf24" : "#ffc658",
+        DONE: isDark ? "#34d399" : "#82ca9d",
+      } as Record<Task["status"], string>,
+      focusBar: isDark ? "#34d399" : "#8884d8",
       pie: isDark
         ? ["#34d399", "#60a5fa", "#fbbf24", "#fb923c"]
         : ["#8884d8", "#82ca9d", "#ffc658", "#ff8042"],
@@ -124,7 +129,14 @@ export default function StatsPage() {
               tick={{ fill: chartColors.text }}
             />
             <Tooltip />
-            <Bar dataKey="count" fill={chartColors.bar} />
+            <Bar dataKey="count">
+              {statusData.map((s) => (
+                <Cell
+                  key={s.status}
+                  fill={chartColors.bar[s.status as keyof typeof chartColors.bar]}
+                />
+              ))}
+            </Bar>
           </BarChart>
         </section>
         <section className="space-y-2">
@@ -169,7 +181,7 @@ export default function StatsPage() {
               tick={{ fill: chartColors.text }}
             />
             <Tooltip />
-            <Bar dataKey="minutes" fill={chartColors.bar} />
+            <Bar dataKey="minutes" fill={chartColors.focusBar} />
           </BarChart>
         </section>
       </main>


### PR DESCRIPTION
## Summary
- map task status to theme-aware bar colors on stats chart
- apply status colors via `<Cell>` elements and keep separate focus bar color

## Testing
- `npm run lint`
- `npx vitest src/app/stats/page.test.tsx -u`
- `CI=true npx vitest src/app/stats/page.test.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b75a6fe2a88320b7aaf7d3cc70ba31