### PR TITLE
feat: add stat card component

### DIFF
--- a/src/app/stats/__snapshots__/page.test.tsx.snap
+++ b/src/app/stats/__snapshots__/page.test.tsx.snap
@@ -13,17 +13,112 @@ exports[`StatsPage > visual regression > matches dark theme snapshot 1`] = `
       </h1>
     </header>
     <section
-      class="space-y-2"
+      class="grid grid-cols-1 gap-4 sm:grid-cols-2"
     >
-      <p>
-        Total Tasks: 
-        2
-      </p>
-      <p>
-        Completion Rate: 
-        50
-        %
-      </p>
+      <div
+        class="flex items-center gap-3 rounded-md bg-white p-4 shadow dark:bg-neutral-800"
+      >
+        <svg
+          class="lucide lucide-list h-6 w-6 text-indigo-600 dark:text-indigo-400"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <line
+            x1="8"
+            x2="21"
+            y1="6"
+            y2="6"
+          />
+          <line
+            x1="8"
+            x2="21"
+            y1="12"
+            y2="12"
+          />
+          <line
+            x1="8"
+            x2="21"
+            y1="18"
+            y2="18"
+          />
+          <line
+            x1="3"
+            x2="3.01"
+            y1="6"
+            y2="6"
+          />
+          <line
+            x1="3"
+            x2="3.01"
+            y1="12"
+            y2="12"
+          />
+          <line
+            x1="3"
+            x2="3.01"
+            y1="18"
+            y2="18"
+          />
+        </svg>
+        <div
+          class="flex flex-col"
+        >
+          <span
+            class="text-sm text-neutral-600 dark:text-neutral-400"
+          >
+            Total Tasks
+          </span>
+          <span
+            class="text-xl font-semibold text-neutral-900 dark:text-neutral-100"
+          >
+            2
+          </span>
+        </div>
+      </div>
+      <div
+        class="flex items-center gap-3 rounded-md bg-white p-4 shadow dark:bg-neutral-800"
+      >
+        <svg
+          class="lucide lucide-circle-check-big h-6 w-6 text-green-600 dark:text-green-400"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M21.801 10A10 10 0 1 1 17 3.335"
+          />
+          <path
+            d="m9 11 3 3L22 4"
+          />
+        </svg>
+        <div
+          class="flex flex-col"
+        >
+          <span
+            class="text-sm text-neutral-600 dark:text-neutral-400"
+          >
+            Completion Rate
+          </span>
+          <span
+            class="text-xl font-semibold text-neutral-900 dark:text-neutral-100"
+          >
+            50%
+          </span>
+        </div>
+      </div>
     </section>
     <section
       class="space-y-2"
@@ -121,17 +216,112 @@ exports[`StatsPage > visual regression > matches light theme snapshot 1`] = `
       </h1>
     </header>
     <section
-      class="space-y-2"
+      class="grid grid-cols-1 gap-4 sm:grid-cols-2"
     >
-      <p>
-        Total Tasks: 
-        2
-      </p>
-      <p>
-        Completion Rate: 
-        50
-        %
-      </p>
+      <div
+        class="flex items-center gap-3 rounded-md bg-white p-4 shadow dark:bg-neutral-800"
+      >
+        <svg
+          class="lucide lucide-list h-6 w-6 text-indigo-600 dark:text-indigo-400"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <line
+            x1="8"
+            x2="21"
+            y1="6"
+            y2="6"
+          />
+          <line
+            x1="8"
+            x2="21"
+            y1="12"
+            y2="12"
+          />
+          <line
+            x1="8"
+            x2="21"
+            y1="18"
+            y2="18"
+          />
+          <line
+            x1="3"
+            x2="3.01"
+            y1="6"
+            y2="6"
+          />
+          <line
+            x1="3"
+            x2="3.01"
+            y1="12"
+            y2="12"
+          />
+          <line
+            x1="3"
+            x2="3.01"
+            y1="18"
+            y2="18"
+          />
+        </svg>
+        <div
+          class="flex flex-col"
+        >
+          <span
+            class="text-sm text-neutral-600 dark:text-neutral-400"
+          >
+            Total Tasks
+          </span>
+          <span
+            class="text-xl font-semibold text-neutral-900 dark:text-neutral-100"
+          >
+            2
+          </span>
+        </div>
+      </div>
+      <div
+        class="flex items-center gap-3 rounded-md bg-white p-4 shadow dark:bg-neutral-800"
+      >
+        <svg
+          class="lucide lucide-circle-check-big h-6 w-6 text-green-600 dark:text-green-400"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M21.801 10A10 10 0 1 1 17 3.335"
+          />
+          <path
+            d="m9 11 3 3L22 4"
+          />
+        </svg>
+        <div
+          class="flex flex-col"
+        >
+          <span
+            class="text-sm text-neutral-600 dark:text-neutral-400"
+          >
+            Completion Rate
+          </span>
+          <span
+            class="text-xl font-semibold text-neutral-900 dark:text-neutral-100"
+          >
+            50%
+          </span>
+        </div>
+      </div>
     </section>
     <section
       class="space-y-2"

--- a/src/app/stats/page.test.tsx
+++ b/src/app/stats/page.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import React from 'react';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, within } from '@testing-library/react';
 import { describe, it, expect, vi, afterEach, beforeAll, beforeEach } from 'vitest';
 import * as matchers from '@testing-library/jest-dom/matchers';
 
@@ -77,8 +77,17 @@ describe('StatsPage', () => {
     });
 
     render(<StatsPage />);
-    expect(screen.getByText('Total Tasks: 3')).toBeInTheDocument();
-    expect(screen.getByText('Completion Rate: 67%')).toBeInTheDocument();
+    const totalCardLabel = screen.getByText('Total Tasks');
+    const totalCard = totalCardLabel.parentElement?.parentElement as HTMLElement;
+    expect(totalCard).toBeInTheDocument();
+    expect(within(totalCard).getByText('3')).toBeInTheDocument();
+    expect(totalCard.querySelector('svg')).toBeTruthy();
+
+    const rateCardLabel = screen.getByText('Completion Rate');
+    const rateCard = rateCardLabel.parentElement?.parentElement as HTMLElement;
+    expect(rateCard).toBeInTheDocument();
+    expect(within(rateCard).getByText('67%')).toBeInTheDocument();
+    expect(rateCard.querySelector('svg')).toBeTruthy();
     expect(screen.getByText('TODO: 1')).toBeInTheDocument();
     expect(screen.getByText('DONE: 2')).toBeInTheDocument();
     expect(screen.getByText('Math: 2')).toBeInTheDocument();

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -17,6 +17,8 @@ import {
 import { api } from "@/server/api/react";
 import type { RouterOutputs } from "@/server/api/root";
 import { ErrorBoundary } from "@/components/error-boundary";
+import { StatCard } from "@/components/ui/stat-card";
+import { CheckCircle, List } from "lucide-react";
 
 type Task = RouterOutputs["task"]["list"][number];
 
@@ -99,9 +101,19 @@ export default function StatsPage() {
         <header>
           <h1 className="text-2xl font-semibold">Task Statistics</h1>
         </header>
-        <section className="space-y-2">
-          <p>Total Tasks: {total}</p>
-          <p>Completion Rate: {completionRate}%</p>
+        <section className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <StatCard
+            icon={<List className="h-6 w-6 text-indigo-600 dark:text-indigo-400" />}
+            label="Total Tasks"
+            value={total}
+          />
+          <StatCard
+            icon={
+              <CheckCircle className="h-6 w-6 text-green-600 dark:text-green-400" />
+            }
+            label="Completion Rate"
+            value={`${completionRate}%`}
+          />
         </section>
         <section className="space-y-2">
           <h2 className="text-xl font-medium">By Status</h2>

--- a/src/components/ui/stat-card.tsx
+++ b/src/components/ui/stat-card.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+export interface StatCardProps {
+  icon: React.ReactNode;
+  label: string;
+  value: string | number;
+}
+
+export function StatCard({ icon, label, value }: StatCardProps) {
+  return (
+    <div className="flex items-center gap-3 rounded-md bg-white p-4 shadow dark:bg-neutral-800">
+      {icon}
+      <div className="flex flex-col">
+        <span className="text-sm text-neutral-600 dark:text-neutral-400">{label}</span>
+        <span className="text-xl font-semibold text-neutral-900 dark:text-neutral-100">{value}</span>
+      </div>
+    </div>
+  );
+}
+
+export default StatCard;
+


### PR DESCRIPTION
## Summary
- add reusable StatCard component with icon, label, and value
- replace stats metrics with StatCards using List and CheckCircle icons
- test StatCard rendering and update visual snapshots

## Testing
- `npm run lint`
- `CI=true npm test -- src/app/stats/page.test.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b75a72310483208f3dc9f372aa43ba