### PR TITLE
feat: add navigation from stats charts

### DIFF
--- a/src/app/stats/page.test.tsx
+++ b/src/app/stats/page.test.tsx
@@ -4,6 +4,33 @@ import { render, screen, cleanup } from '@testing-library/react';
 import { describe, it, expect, vi, afterEach, beforeAll, beforeEach } from 'vitest';
 import * as matchers from '@testing-library/jest-dom/matchers';
 
+const barHandlers: Array<(payload: any) => void> = [];
+const pieHandlers: Array<(payload: any) => void> = [];
+vi.mock('recharts', () => {
+  const Div = (props: any) => React.createElement('div', props);
+  const Null = () => null;
+  const Bar = (props: any) => {
+    if (props.onClick) barHandlers.push(props.onClick);
+    return null;
+  };
+  const Pie = (props: any) => {
+    if (props.onClick) pieHandlers.push(props.onClick);
+    return null;
+  };
+  const Cell = () => null;
+  return {
+    BarChart: Div,
+    Bar,
+    XAxis: Null,
+    YAxis: Null,
+    Tooltip: Null,
+    PieChart: Div,
+    Pie,
+    Cell,
+    ResponsiveContainer: Div,
+  } as any;
+});
+
 vi.mock('@/server/api/react', () => ({
   api: {
     task: {
@@ -25,6 +52,7 @@ vi.mock('next-themes', () => ({
 }));
 
 import { api } from '@/server/api/react';
+import { useRouter } from 'next/navigation';
 import StatsPage from './page';
 import { ErrorBoundary } from '@/components/error-boundary';
 
@@ -59,6 +87,8 @@ afterEach(() => {
   cleanup();
   vi.clearAllMocks();
   mockTheme = 'light';
+  barHandlers.length = 0;
+  pieHandlers.length = 0;
 });
 
 describe('StatsPage', () => {
@@ -126,6 +156,38 @@ describe('StatsPage', () => {
       </ErrorBoundary>
     );
     expect(screen.getByText('Failed to load stats')).toBeInTheDocument();
+  });
+
+  it('navigates to tasks filtered by status when a bar is clicked', () => {
+    taskUseQueryMock.mockReturnValue({
+      data: [
+        { id: '1', status: 'DONE', subject: 'Math', title: 'Task 1' },
+      ],
+      isLoading: false,
+    });
+    focusUseQueryMock.mockReturnValue({ data: [], isLoading: false });
+
+    render(<StatsPage />);
+    const router = useRouter();
+    expect(barHandlers.length).toBeGreaterThan(0);
+    barHandlers[0]({ status: 'DONE' });
+    expect(router.push).toHaveBeenCalledWith('/tasks?status=DONE');
+  });
+
+  it('navigates to tasks filtered by subject when a pie slice is clicked', () => {
+    taskUseQueryMock.mockReturnValue({
+      data: [
+        { id: '1', status: 'TODO', subject: 'Math', title: 'Task 1' },
+      ],
+      isLoading: false,
+    });
+    focusUseQueryMock.mockReturnValue({ data: [], isLoading: false });
+
+    render(<StatsPage />);
+    const router = useRouter();
+    expect(pieHandlers.length).toBeGreaterThan(0);
+    pieHandlers[0]({ subject: 'Math' });
+    expect(router.push).toHaveBeenCalledWith('/tasks?subject=Math');
   });
 
   describe('visual regression', () => {

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { useTheme } from "next-themes";
 import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
 import {
   BarChart,
   Bar,
@@ -22,6 +23,7 @@ type Task = RouterOutputs["task"]["list"][number];
 
 export default function StatsPage() {
   const { data: session } = useSession();
+  const router = useRouter();
   const { data, isLoading, error } = api.task.list.useQuery(undefined, {
     enabled: !!session,
   });
@@ -124,7 +126,16 @@ export default function StatsPage() {
               tick={{ fill: chartColors.text }}
             />
             <Tooltip />
-            <Bar dataKey="count" fill={chartColors.bar} />
+            <Bar
+              dataKey="count"
+              fill={chartColors.bar}
+              onClick={(data: any) =>
+                router.push(
+                  `/tasks?status=${encodeURIComponent(data.status as string)}`
+                )
+              }
+              className="cursor-pointer"
+            />
           </BarChart>
         </section>
         <section className="space-y-2">
@@ -137,7 +148,18 @@ export default function StatsPage() {
             ))}
           </ul>
           <PieChart width={400} height={200}>
-            <Pie data={subjectData} dataKey="count" nameKey="subject" outerRadius={80}>
+            <Pie
+              data={subjectData}
+              dataKey="count"
+              nameKey="subject"
+              outerRadius={80}
+              onClick={(data: any) =>
+                router.push(
+                  `/tasks?subject=${encodeURIComponent(data.subject as string)}`
+                )
+              }
+              className="cursor-pointer"
+            >
               {subjectData.map((_, index) => (
                 <Cell
                   key={`cell-${index}`}


### PR DESCRIPTION
## Summary
- navigate from stats chart bars and pie slices to filtered tasks
- test stats chart navigation

## Testing
- `npm test src/app/stats/page.test.tsx`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b75ab3a2688320b6e8435a40ec9104