### PR TITLE
feat: export stats to csv

### DIFF
--- a/src/app/stats/__snapshots__/page.test.tsx.snap
+++ b/src/app/stats/__snapshots__/page.test.tsx.snap
@@ -5,12 +5,19 @@ exports[`StatsPage > visual regression > matches dark theme snapshot 1`] = `
   <main
     class="space-y-6 text-neutral-900 dark:text-neutral-100"
   >
-    <header>
+    <header
+      class="flex items-center justify-between"
+    >
       <h1
         class="text-2xl font-semibold"
       >
         Task Statistics
       </h1>
+      <button
+        class="inline-flex items-center justify-center rounded px-4 py-2 text-sm font-medium focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed transition-colors bg-black text-white dark:bg-white dark:text-black"
+      >
+        Export CSV
+      </button>
     </header>
     <section
       class="space-y-2"
@@ -113,12 +120,19 @@ exports[`StatsPage > visual regression > matches light theme snapshot 1`] = `
   <main
     class="space-y-6 text-neutral-900 dark:text-neutral-100"
   >
-    <header>
+    <header
+      class="flex items-center justify-between"
+    >
       <h1
         class="text-2xl font-semibold"
       >
         Task Statistics
       </h1>
+      <button
+        class="inline-flex items-center justify-center rounded px-4 py-2 text-sm font-medium focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed transition-colors bg-black text-white dark:bg-white dark:text-black"
+      >
+        Export CSV
+      </button>
     </header>
     <section
       class="space-y-2"

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -16,7 +16,9 @@ import {
 } from "recharts";
 import { api } from "@/server/api/react";
 import type { RouterOutputs } from "@/server/api/root";
+import { exportStatsToCSV } from "@/lib/export";
 import { ErrorBoundary } from "@/components/error-boundary";
+import { Button } from "@/components/ui/button";
 
 type Task = RouterOutputs["task"]["list"][number];
 
@@ -93,11 +95,16 @@ export default function StatsPage() {
       count: Number(count),
     }));
 
+  const handleExport = () => {
+    exportStatsToCSV({ tasks, statusData, subjectData, focusByTask });
+  };
+
   return (
     <ErrorBoundary fallback={<main>Failed to load stats</main>}>
       <main className="space-y-6 text-neutral-900 dark:text-neutral-100">
-        <header>
+        <header className="flex items-center justify-between">
           <h1 className="text-2xl font-semibold">Task Statistics</h1>
+          <Button onClick={handleExport}>Export CSV</Button>
         </header>
         <section className="space-y-2">
           <p>Total Tasks: {total}</p>

--- a/src/lib/export.test.ts
+++ b/src/lib/export.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { statsToCSV } from './export';
+
+describe('statsToCSV', () => {
+  it('generates csv for stats', () => {
+    const csv = statsToCSV({
+      tasks: [
+        { id: '1', title: 'Task 1', status: 'TODO', subject: 'Math' },
+        { id: '2', title: 'Task 2', status: 'DONE', subject: 'Science' },
+      ],
+      statusData: [
+        { status: 'TODO', count: 1 },
+        { status: 'DONE', count: 1 },
+      ],
+      subjectData: [
+        { subject: 'Math', count: 1 },
+        { subject: 'Science', count: 1 },
+      ],
+      focusByTask: [
+        { id: '1', title: 'Task 1', minutes: 30 },
+      ],
+    });
+    expect(csv).toBe(
+      [
+        'id,title,status,subject',
+        '1,Task 1,TODO,Math',
+        '2,Task 2,DONE,Science',
+        '',
+        'status,count',
+        'TODO,1',
+        'DONE,1',
+        '',
+        'subject,count',
+        'Math,1',
+        'Science,1',
+        '',
+        'id,title,minutes',
+        '1,Task 1,30',
+      ].join('\n')
+    );
+  });
+
+  it('escapes commas and quotes', () => {
+    const csv = statsToCSV({
+      tasks: [
+        { id: '1', title: 'Task "A, B"', status: 'TODO', subject: 'Sci,ence' },
+      ],
+      statusData: [],
+      subjectData: [],
+      focusByTask: [],
+    });
+    expect(csv).toBe(
+      [
+        'id,title,status,subject',
+        '1,"Task ""A, B""",TODO,"Sci,ence"',
+        '',
+        'status,count',
+        '',
+        'subject,count',
+        '',
+        'id,title,minutes',
+      ].join('\n')
+    );
+  });
+});
+

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -1,0 +1,56 @@
+import type { RouterOutputs } from '@/server/api/root';
+
+type Task = RouterOutputs['task']['list'][number];
+
+export interface StatsExportData {
+  tasks: Task[];
+  statusData: { status: string; count: number }[];
+  subjectData: { subject: string; count: number }[];
+  focusByTask: { id: string; title: string; minutes: number }[];
+}
+
+function escapeValue(value: string | number): string {
+  const str = String(value ?? '');
+  return /[",\n]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str;
+}
+
+export function statsToCSV(data: StatsExportData): string {
+  const lines: string[] = [
+    'id,title,status,subject',
+    ...data.tasks.map((t) =>
+      [t.id, t.title, t.status, t.subject ?? ''].map(escapeValue).join(',')
+    ),
+    '',
+    'status,count',
+    ...data.statusData.map((s) =>
+      [s.status, s.count].map(escapeValue).join(',')
+    ),
+    '',
+    'subject,count',
+    ...data.subjectData.map((s) =>
+      [s.subject, s.count].map(escapeValue).join(',')
+    ),
+    '',
+    'id,title,minutes',
+    ...data.focusByTask.map((f) =>
+      [f.id, f.title, f.minutes].map(escapeValue).join(',')
+    ),
+  ];
+  return lines.join('\n');
+}
+
+export function exportStatsToCSV(
+  data: StatsExportData,
+  filename = 'stats.csv'
+): string {
+  const csv = statsToCSV(data);
+  const blob = new Blob([csv], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+  return csv;
+}
+


### PR DESCRIPTION
## Summary
- add CSV export utility for stats
- provide export button on stats page
- cover CSV generation and escaping with tests

## Testing
- `npm test src/app/stats/page.test.tsx src/lib/export.test.ts`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b75ab9f5688320879fdc75369080ae