### PR TITLE
fix: respect timezone for stats filtering

### DIFF
--- a/src/app/stats/page.test.tsx
+++ b/src/app/stats/page.test.tsx
@@ -26,6 +26,11 @@ vi.mock('@/server/api/react', () => ({
         useQuery: vi.fn(() => ({ data: [] })),
       },
     },
+    user: {
+      get: {
+        useQuery: vi.fn(() => ({ data: {} })),
+      },
+    },
   },
 }));
 
@@ -141,10 +146,13 @@ describe('StatsPage', () => {
   });
 
   it('filters tasks by subject', () => {
-    taskUseQueryMock.mockReturnValue({
-      data: sampleTasks,
+    taskUseQueryMock.mockImplementation((input) => ({
+      data:
+        input?.subject === 'Math'
+          ? sampleTasks.filter((t) => t.subject === 'Math')
+          : sampleTasks,
       isLoading: false,
-    });
+    }));
     focusUseQueryMock.mockReturnValue({ data: [], isLoading: false });
 
     render(<StatsPage />);
@@ -157,10 +165,13 @@ describe('StatsPage', () => {
   });
 
   it('filters tasks by status', () => {
-    taskUseQueryMock.mockReturnValue({
-      data: sampleTasks,
+    taskUseQueryMock.mockImplementation((input) => ({
+      data:
+        input?.filter === 'archive'
+          ? sampleTasks.filter((t) => t.status === 'DONE')
+          : sampleTasks,
       isLoading: false,
-    });
+    }));
     focusUseQueryMock.mockReturnValue({ data: [], isLoading: false });
 
     render(<StatsPage />);


### PR DESCRIPTION
## Summary
- delegate stats filtering to API to match server timezone logic
- adjust stats page tests for server-side filters

## Testing
- `npm run lint`
- `CI=true npx vitest src/app/stats/page.test.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b75f349b6c832097726753ce9859ec