### PR TITLE
fix: hook up stats navigation to task filters

### DIFF
--- a/src/app/courses/[id]/page.tsx
+++ b/src/app/courses/[id]/page.tsx
@@ -29,6 +29,7 @@ export default function CoursePage({ params }: { params: { id: string } }) {
         <TaskList
           filter="all"
           subject={null}
+          status={null}
           priority={null}
           courseId={id}
           projectId={null}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,19 +1,39 @@
 "use client";
 
 import React, { useState, useEffect, Suspense, useRef } from "react";
+import { useSearchParams } from "next/navigation";
 import { TaskList } from "@/components/task-list";
 import { TaskModal } from "@/components/task-modal";
 import { Button } from "@/components/ui/button";
 import { clsx } from "clsx";
+import type { TaskStatus } from "@/components/status-dropdown";
 // Controls moved to global nav bar: AccountMenu, ThemeToggle, ShortcutsPopover
 
 type Priority = "LOW" | "MEDIUM" | "HIGH";
 
 export default function HomePage() {
+  return (
+    <Suspense fallback={null}>
+      <HomePageContent />
+    </Suspense>
+  );
+}
+
+function HomePageContent() {
   const [filter, setFilter] = useState<"all" | "overdue" | "today" | "archive">(
     "all"
   );
-  const [subject] = useState<string | null>(null);
+  const searchParams = useSearchParams();
+  const statusParam = searchParams.get("status");
+  const subjectParam = searchParams.get("subject");
+  const status: TaskStatus | null =
+    statusParam === "TODO" ||
+    statusParam === "IN_PROGRESS" ||
+    statusParam === "DONE" ||
+    statusParam === "CANCELLED"
+      ? (statusParam as TaskStatus)
+      : null;
+  const subject = subjectParam;
   const [priority] = useState<Priority | null>(null);
   const [courseId] = useState<string | null>(null);
   const [projectId] = useState<string | null>(null);
@@ -111,6 +131,7 @@ export default function HomePage() {
           <TaskList
             filter={filter}
             subject={subject}
+            status={status}
             priority={priority}
             courseId={courseId}
             projectId={projectId}

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -65,6 +65,7 @@ export default function ProjectPage({ params }: { params: { id: string } }) {
         <TaskList
           filter="all"
           subject={null}
+          status={null}
           priority={null}
           courseId={null}
           projectId={id}

--- a/src/app/stats/page.test.tsx
+++ b/src/app/stats/page.test.tsx
@@ -171,7 +171,7 @@ describe('StatsPage', () => {
     const router = useRouter();
     expect(barHandlers.length).toBeGreaterThan(0);
     barHandlers[0]({ status: 'DONE' });
-    expect(router.push).toHaveBeenCalledWith('/tasks?status=DONE');
+    expect(router.push).toHaveBeenCalledWith('/?status=DONE');
   });
 
   it('navigates to tasks filtered by subject when a pie slice is clicked', () => {
@@ -187,7 +187,7 @@ describe('StatsPage', () => {
     const router = useRouter();
     expect(pieHandlers.length).toBeGreaterThan(0);
     pieHandlers[0]({ subject: 'Math' });
-    expect(router.push).toHaveBeenCalledWith('/tasks?subject=Math');
+    expect(router.push).toHaveBeenCalledWith('/?subject=Math');
   });
 
   describe('visual regression', () => {

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -131,7 +131,7 @@ export default function StatsPage() {
               fill={chartColors.bar}
               onClick={(data: any) =>
                 router.push(
-                  `/tasks?status=${encodeURIComponent(data.status as string)}`
+                  `/?status=${encodeURIComponent(data.status as string)}`
                 )
               }
               className="cursor-pointer"
@@ -155,7 +155,9 @@ export default function StatsPage() {
               outerRadius={80}
               onClick={(data: any) =>
                 router.push(
-                  `/tasks?subject=${encodeURIComponent(data.subject as string)}`
+                  `/?subject=${encodeURIComponent(
+                    data.subject as string
+                  )}`
                 )
               }
               className="cursor-pointer"

--- a/src/components/task-list.test.tsx
+++ b/src/components/task-list.test.tsx
@@ -43,6 +43,7 @@ describe('TaskList', () => {
       <TaskList
         filter="all"
         subject={null}
+        status={null}
         priority={null}
         courseId={null}
         projectId={null}
@@ -70,6 +71,7 @@ describe('TaskList', () => {
       <TaskList
         filter="all"
         subject={null}
+        status={null}
         priority={null}
         courseId={null}
         projectId={null}
@@ -99,6 +101,7 @@ describe('TaskList', () => {
       <TaskList
         filter="all"
         subject={null}
+        status={null}
         priority={null}
         courseId={null}
         projectId={null}
@@ -126,6 +129,7 @@ describe('TaskList', () => {
       <TaskList
         filter="all"
         subject={null}
+        status={null}
         priority={null}
         courseId={null}
         projectId={null}
@@ -153,6 +157,7 @@ describe('TaskList', () => {
       <TaskList
         filter="all"
         subject={null}
+        status={null}
         priority={null}
         courseId={null}
         projectId={null}
@@ -181,6 +186,7 @@ describe('TaskList', () => {
       <TaskList
         filter="all"
         subject={null}
+        status={null}
         priority={null}
         courseId={null}
         projectId={null}

--- a/src/components/task-list.tsx
+++ b/src/components/task-list.tsx
@@ -34,6 +34,7 @@ type Priority = "LOW" | "MEDIUM" | "HIGH";
 interface TaskListProps {
   filter: "all" | "overdue" | "today" | "archive";
   subject: string | null;
+  status: TaskStatus | null;
   priority: Priority | null;
   courseId: string | null;
   projectId: string | null;
@@ -44,6 +45,7 @@ interface TaskListProps {
 export function TaskList({
   filter,
   subject,
+  status,
   priority,
   courseId,
   projectId,
@@ -58,6 +60,7 @@ export function TaskList({
     const base: any = {
       filter,
       subject: subject ?? undefined,
+      status: status ?? undefined,
       priority: priority ?? undefined,
       courseId: courseId ?? undefined,
       projectId: projectId ?? undefined,
@@ -74,7 +77,7 @@ export function TaskList({
       base.todayEnd = endLocal;
     }
     return base;
-  }, [filter, subject, priority, courseId, projectId, user.data?.timezone]);
+  }, [filter, subject, status, priority, courseId, projectId, user.data?.timezone]);
 
   const PAGE_SIZE = 20;
   const tasks = api.task.list.useInfiniteQuery(

--- a/src/server/api/routers/task.test.ts
+++ b/src/server/api/routers/task.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { TaskPriority, RecurrenceType } from '@prisma/client';
+import { TaskPriority, RecurrenceType, TaskStatus } from '@prisma/client';
 
 // Define hoisted fns for module mock
 const hoisted = vi.hoisted(() => {
@@ -106,6 +106,15 @@ describe('taskRouter.list ordering', () => {
     expect(hoisted.findMany).toHaveBeenCalledTimes(1);
     const arg = hoisted.findMany.mock.calls[0][0];
     expect(arg.where).toEqual({ userId: 'user1', parentId: 't1' });
+  });
+
+  it('filters by status when provided', async () => {
+    await taskRouter
+      .createCaller(ctx)
+      .list({ filter: 'all', status: TaskStatus.DONE });
+    expect(hoisted.findMany).toHaveBeenCalledTimes(1);
+    const arg = hoisted.findMany.mock.calls[0][0];
+    expect(arg.where).toEqual({ userId: 'user1', status: TaskStatus.DONE });
   });
 
   it('uses session timezone for today range when available', async () => {

--- a/src/server/api/routers/task.ts
+++ b/src/server/api/routers/task.ts
@@ -26,6 +26,7 @@ export const taskRouter = router({
         .object({
           filter: z.enum(['all', 'overdue', 'today', 'archive']).optional(),
           subject: z.string().optional(),
+          status: z.nativeEnum(TaskStatus).optional(),
           priority: z.nativeEnum(TaskPriority).optional(),
           courseId: z.string().optional(),
           projectId: z.string().optional(),
@@ -44,6 +45,7 @@ export const taskRouter = router({
       const userId = requireUserId(ctx);
       const filter = input?.filter ?? 'all';
       const subject = input?.subject;
+      const status = input?.status;
       const priority = input?.priority;
       const courseId = input?.courseId;
       const projectId = input?.projectId;
@@ -97,6 +99,9 @@ export const taskRouter = router({
 
       if (subject) {
         where = { ...where, subject };
+      }
+      if (status) {
+        where = { ...where, status };
       }
       if (priority) {
         where = { ...where, priority };


### PR DESCRIPTION
## Summary
- push stats chart clicks to root task list instead of missing route
- read `status` and `subject` query params to filter tasks
- add status filter support to API and task list component

## Testing
- `npm test src/app/stats/page.test.tsx src/app/page.test.tsx src/components/task-list.test.tsx src/server/api/routers/task.test.ts`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b75f50359c832092da71039ece0ffe