### PR TITLE
refactor: centralize task relationship validation

### DIFF
--- a/src/server/api/routers/task.test.ts
+++ b/src/server/api/routers/task.test.ts
@@ -49,9 +49,10 @@ vi.mock('@/server/db', () => ({
   },
 }));
 
-import { taskRouter } from './task';
+import * as taskModule from './task';
 import { cache } from '@/server/cache';
 
+const { taskRouter } = taskModule;
 const ctx = { session: { user: { id: 'user1' } } } as any;
 
 describe('taskRouter.list ordering', () => {
@@ -279,6 +280,19 @@ describe('taskRouter.create', () => {
       }),
     });
   });
+
+  it('validates relationships via helper', async () => {
+    const spy = vi.spyOn(taskModule, 'validateTaskRelationships');
+    await taskRouter
+      .createCaller(ctx)
+      .create({ title: 'a', projectId: 'p1', courseId: 'c1', parentId: 't1' });
+    expect(spy).toHaveBeenCalledWith('user1', {
+      projectId: 'p1',
+      courseId: 'c1',
+      parentId: 't1',
+    });
+    spy.mockRestore();
+  });
 });
 
 describe('taskRouter.update recurrence', () => {
@@ -318,6 +332,19 @@ describe('taskRouter.update project/course', () => {
       where: { id: '1' },
       data: { projectId: 'p1', courseId: null },
     });
+  });
+
+  it('validates relationships via helper', async () => {
+    const spy = vi.spyOn(taskModule, 'validateTaskRelationships');
+    await taskRouter
+      .createCaller(ctx)
+      .update({ id: '1', projectId: 'p1', courseId: null, parentId: 't1' });
+    expect(spy).toHaveBeenCalledWith('user1', {
+      projectId: 'p1',
+      courseId: null,
+      parentId: 't1',
+    });
+    spy.mockRestore();
   });
 });
 

--- a/src/server/api/routers/task.ts
+++ b/src/server/api/routers/task.ts
@@ -18,6 +18,26 @@ const requireUserId = (ctx: { session?: { user?: { id?: string } | null } | null
   if (!id) throw new TRPCError({ code: 'UNAUTHORIZED' });
   return id;
 };
+
+export const validateTaskRelationships = async (
+  userId: string,
+  ids: { projectId?: string | null; courseId?: string | null; parentId?: string | null },
+) => {
+  const { projectId, courseId, parentId } = ids;
+  if (typeof projectId === 'string') {
+    const project = await db.project.findFirst({ where: { id: projectId, userId } });
+    if (!project) throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid projectId' });
+  }
+  if (typeof courseId === 'string') {
+    const course = await db.course.findFirst({ where: { id: courseId, userId } });
+    if (!course) throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid courseId' });
+  }
+  if (typeof parentId === 'string') {
+    const parent = await db.task.findFirst({ where: { id: parentId, userId } });
+    if (!parent) throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid parentId' });
+  }
+};
+
 export const taskRouter = router({
   // List tasks for the authenticated user
   list: protectedProcedure
@@ -183,19 +203,11 @@ export const taskRouter = router({
         throw new TRPCError({ code: 'BAD_REQUEST', message: 'Due date cannot be in the past' });
       }
       const userId = requireUserId(ctx);
-      // Validate foreign keys to avoid FK violations and cross-user links
-      if (input.projectId) {
-        const project = await db.project.findFirst({ where: { id: input.projectId, userId } });
-        if (!project) throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid projectId' });
-      }
-      if (input.courseId) {
-        const course = await db.course.findFirst({ where: { id: input.courseId, userId } });
-        if (!course) throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid courseId' });
-      }
-      if (input.parentId) {
-        const parent = await db.task.findFirst({ where: { id: input.parentId, userId } });
-        if (!parent) throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid parentId' });
-      }
+      await validateTaskRelationships(userId, {
+        projectId: input.projectId,
+        courseId: input.courseId,
+        parentId: input.parentId,
+      });
       const created = await db.task.create({
         data: {
           userId,
@@ -248,28 +260,11 @@ export const taskRouter = router({
         if (typeof value !== 'undefined') data[key] = value;
       }
 
-      // Validate foreign keys belong to the user before updating, to avoid FK errors
-      if (Object.prototype.hasOwnProperty.call(data, 'projectId')) {
-        const pid = data.projectId as string | null | undefined;
-        if (pid && typeof pid === 'string') {
-          const project = await db.project.findFirst({ where: { id: pid, userId } });
-          if (!project) throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid projectId' });
-        }
-      }
-      if (Object.prototype.hasOwnProperty.call(data, 'courseId')) {
-        const cid = data.courseId as string | null | undefined;
-        if (cid && typeof cid === 'string') {
-          const course = await db.course.findFirst({ where: { id: cid, userId } });
-          if (!course) throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid courseId' });
-        }
-      }
-      if (Object.prototype.hasOwnProperty.call(data, 'parentId')) {
-        const pid = data.parentId as string | null | undefined;
-        if (pid && typeof pid === 'string') {
-          const parent = await db.task.findFirst({ where: { id: pid, userId } });
-          if (!parent) throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid parentId' });
-        }
-      }
+      await validateTaskRelationships(userId, {
+        projectId: data.projectId as string | null | undefined,
+        courseId: data.courseId as string | null | undefined,
+        parentId: data.parentId as string | null | undefined,
+      });
       let result: Task;
       if (Object.keys(data).length === 0) {
         result = existing;


### PR DESCRIPTION
## Summary
- add shared `validateTaskRelationships` helper for validating project, course, and parent IDs
- use helper in task creation and update flows
- test that relationship validation helper is invoked

## Testing
- `npm run lint`
- `CI=true npm test` *(fails: [vitest] No "Label" export is defined on the "recharts" mock)*

------
https://chatgpt.com/codex/tasks/task_e_68b76fee96c88320a7c828a648b69050