### PR TITLE
refactor: modularize task router with sub-routers

### DIFF
--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -1,10 +1,10 @@
 import { inferRouterOutputs } from '@trpc/server';
 import { router } from './trpc';
-import { taskRouter } from './routers/task';
+import { courseRouter } from './routers/course';
 import { eventRouter } from './routers/event';
 import { focusRouter } from './routers/focus';
 import { projectRouter } from './routers/project';
-import { courseRouter } from './routers/course';
+import { taskRouter } from './routers/task';
 import { userRouter } from './routers/user';
 
 export const appRouter = router({

--- a/src/server/api/routers/task/index.ts
+++ b/src/server/api/routers/task/index.ts
@@ -1,0 +1,10 @@
+import { t } from '../../trpc';
+import { taskCrudRouter } from './taskCrud';
+import { taskBulkRouter } from './taskBulk';
+import { taskScheduleRouter } from './taskSchedule';
+
+export const taskRouter = t.mergeRouters(
+  taskCrudRouter,
+  taskBulkRouter,
+  taskScheduleRouter,
+);

--- a/src/server/api/routers/task/taskBulk.ts
+++ b/src/server/api/routers/task/taskBulk.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+import { router, protectedProcedure } from '../../trpc';
+import { db } from '@/server/db';
+import { invalidateTaskListCache, requireUserId } from './utils';
+
+export const taskBulkRouter = router({
+  bulkUpdate: protectedProcedure
+    .input(
+      z.object({
+        ids: z.array(z.string().min(1)),
+        status: z.enum(['TODO', 'IN_PROGRESS', 'DONE', 'CANCELLED']),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      const userId = requireUserId(ctx);
+      await db.task.updateMany({
+        where: { id: { in: input.ids }, userId },
+        data: { status: input.status },
+      });
+      await invalidateTaskListCache();
+      return { success: true };
+    }),
+  bulkDelete: protectedProcedure
+    .input(z.object({ ids: z.array(z.string().min(1)) }))
+    .mutation(async ({ input, ctx }) => {
+      const userId = requireUserId(ctx);
+      await db.$transaction([
+        db.reminder.deleteMany({ where: { taskId: { in: input.ids }, task: { userId } } }),
+        db.event.deleteMany({ where: { taskId: { in: input.ids }, task: { userId } } }),
+        db.task.deleteMany({ where: { id: { in: input.ids }, userId } }),
+      ]);
+      await invalidateTaskListCache();
+      return { success: true };
+    }),
+});

--- a/src/server/api/routers/task/taskSchedule.ts
+++ b/src/server/api/routers/task/taskSchedule.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+import { TRPCError } from '@trpc/server';
+import { router, protectedProcedure } from '../../trpc';
+import { db } from '@/server/db';
+import { invalidateTaskListCache, requireUserId } from './utils';
+
+export const taskScheduleRouter = router({
+  reorder: protectedProcedure
+    .input(z.object({ ids: z.array(z.string().min(1)) }))
+    .mutation(async ({ input, ctx }) => {
+      const userId = requireUserId(ctx);
+      const tasks = await db.task.findMany({
+        where: { id: { in: input.ids }, userId },
+        select: { id: true },
+      });
+      if (tasks.length !== input.ids.length) throw new TRPCError({ code: 'NOT_FOUND' });
+      await db.$transaction(
+        input.ids.map((id, index) =>
+          db.task.update({ where: { id }, data: { position: index + 1 } }),
+        ),
+      );
+      await invalidateTaskListCache();
+      return { success: true };
+    }),
+});

--- a/src/server/api/routers/task/utils.ts
+++ b/src/server/api/routers/task/utils.ts
@@ -1,0 +1,15 @@
+import { TRPCError } from '@trpc/server';
+import { cache } from '@/server/cache';
+
+export const TASK_LIST_CACHE_PREFIX = 'task:list:';
+
+export const buildListCacheKey = (input: unknown, userId: string | null) =>
+  `${TASK_LIST_CACHE_PREFIX}${userId ?? 'null'}:${JSON.stringify(input ?? {})}`;
+
+export const invalidateTaskListCache = () => cache.clear();
+
+export const requireUserId = (ctx: { session?: { user?: { id?: string } | null } | null }) => {
+  const id = ctx.session?.user?.id;
+  if (!id) throw new TRPCError({ code: 'UNAUTHORIZED' });
+  return id;
+};


### PR DESCRIPTION
## Summary
- split task procedures into taskCrud, taskBulk, and taskSchedule sub-routers
- merge task routers under new task/index.ts
- reorder app router imports

## Testing
- `npm run lint`
- `CI=true npm test` *(fails: Vitest caught unhandled errors and several failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b76ff884508320852e6344350b5ea8