### PR TITLE
Optimize interval overlap detection

### DIFF
--- a/src/lib/scheduling.ts
+++ b/src/lib/scheduling.ts
@@ -22,17 +22,36 @@ export function findNonOverlappingSlot(opts: {
   const dayEnd = new Date(start);
   dayEnd.setHours(dayWindowEndHour, 0, 0, 0);
 
+  // Sort and filter relevant intervals to those within the day window
+  const relevant = existing
+    .filter((e) => e.endAt > dayStart && e.startAt < dayEnd)
+    .sort((a, b) => a.startAt.getTime() - b.startAt.getTime());
+
   let candidateStart = start < dayStart ? dayStart : start;
   // Round candidate to nearest step increment
   const ms = candidateStart.getTime();
   const stepMs = stepMinutes * 60_000;
   candidateStart = new Date(Math.ceil(ms / stepMs) * stepMs);
 
+  // Iterate through sorted intervals while advancing the candidate slot
+  let index = 0;
   while (candidateStart < dayEnd) {
     const candidateEnd = new Date(candidateStart.getTime() + durationMinutes * 60_000);
     if (candidateEnd > dayEnd) return null;
     const candidate = { startAt: candidateStart, endAt: candidateEnd };
-    const hasOverlap = existing.some((e) => overlaps(candidate, e));
+
+    // Skip intervals that end before or at the candidate start
+    while (index < relevant.length && relevant[index].endAt <= candidateStart) index++;
+
+    // Check for overlaps with remaining intervals that start before candidate end
+    let hasOverlap = false;
+    for (let j = index; j < relevant.length && relevant[j].startAt < candidateEnd; j++) {
+      if (overlaps(candidate, relevant[j])) {
+        hasOverlap = true;
+        break;
+      }
+    }
+
     if (!hasOverlap) return candidate;
     candidateStart = new Date(candidateStart.getTime() + stepMs);
   }


### PR DESCRIPTION
## Summary
- filter and sort existing intervals before scanning for overlaps
- iterate through sorted intervals to skip irrelevant ranges
- test scheduling logic against out-of-window and unsorted intervals

## Testing
- `npm run lint`
- `CI=true npm test src/lib/scheduling.test.ts`
- `npm run build` *(fails: Expected 1 arguments, but got 0)*

------
https://chatgpt.com/codex/tasks/task_e_68be60dd2fe88320b72a01053f139e3f