### PR TITLE
fix: handle invalid datetime parsing

### DIFF
--- a/src/components/task-modal.tsx
+++ b/src/components/task-modal.tsx
@@ -158,7 +158,8 @@ export function TaskModal({
       <Button
         disabled={create.isPending || update.isPending}
         onClick={() => {
-          const dueAt = dueEnabled && due ? parseLocalDateTime(due) : null;
+          const parsedDue = parseLocalDateTime(due);
+          const dueAt = dueEnabled && parsedDue ? parsedDue : null;
           const recurrenceUntilDate =
             recurrenceUntil ? new Date(`${recurrenceUntil}T23:59:59`) : undefined;
           const recurrenceCountVal =
@@ -267,7 +268,8 @@ export function TaskModal({
                 if (enabled && !due) {
                   const v = defaultEndOfToday();
                   setDue(v);
-                  onDraftDueChange?.(parseLocalDateTime(v));
+                  const parsed = parseLocalDateTime(v);
+                  onDraftDueChange?.(parsed);
                 }
                 if (!enabled) onDraftDueChange?.(null);
               }}
@@ -279,7 +281,8 @@ export function TaskModal({
               value={due}
               onChange={(e) => {
                 setDue(e.target.value);
-                onDraftDueChange?.(e.target.value ? parseLocalDateTime(e.target.value) : null);
+                const parsed = e.target.value ? parseLocalDateTime(e.target.value) : null;
+                onDraftDueChange?.(parsed);
               }}
               disabled={!dueEnabled}
             />

--- a/src/lib/datetime.test.ts
+++ b/src/lib/datetime.test.ts
@@ -15,7 +15,8 @@ describe('datetime utility', () => {
     }
 
     const parsed = parseLocalDateTime(formatted);
-    expect(parsed.getTime()).toBe(date.getTime());
+    expect(parsed).not.toBeNull();
+    expect(parsed?.getTime()).toBe(date.getTime());
 
     process.env.TZ = originalTZ;
   });
@@ -28,5 +29,20 @@ describe('datetime utility', () => {
     expect(
       calculateDurationMinutes(start.toISOString(), end.toISOString())
     ).toBe(90);
+  });
+
+  it('returns null for malformed input', () => {
+    const cases = [
+      '',
+      'not-a-date',
+      '2024-13-01T00:00',
+      '2024-01-32T00:00',
+      '2024-01-01T24:00',
+      '2024-01-01T00:60',
+      '2024/01/01T00:00',
+    ];
+    for (const c of cases) {
+      expect(parseLocalDateTime(c)).toBeNull();
+    }
   });
 });

--- a/src/lib/datetime.ts
+++ b/src/lib/datetime.ts
@@ -6,18 +6,27 @@ export function formatLocalDateTime(date: Date): string {
   return format(date, DATETIME_LOCAL_FORMAT);
 }
 
-export function parseLocalDateTime(value: string): Date {
+export function parseLocalDateTime(value: string): Date | null {
   // Expecting 'yyyy-MM-ddTHH:mm' (no timezone); interpret as local time explicitly
-  const [datePart, timePart] = value.split('T');
-  if (!datePart || !timePart) return new Date(NaN);
-  const [yStr, mStr, dStr] = datePart.split('-');
-  const [hhStr, mmStr] = timePart.split(':');
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/);
+  if (!match) return null;
+  const [, yStr, mStr, dStr, hhStr, mmStr] = match;
   const y = Number(yStr);
-  const m = Number(mStr);
+  const m = Number(mStr) - 1; // JS months are 0-indexed
   const d = Number(dStr);
   const hh = Number(hhStr);
   const mm = Number(mmStr);
-  return new Date(y, (m || 1) - 1, d || 1, hh || 0, mm || 0, 0, 0);
+  const date = new Date(y, m, d, hh, mm, 0, 0);
+  if (
+    date.getFullYear() !== y ||
+    date.getMonth() !== m ||
+    date.getDate() !== d ||
+    date.getHours() !== hh ||
+    date.getMinutes() !== mm
+  ) {
+    return null;
+  }
+  return date;
 }
 
 export function calculateDurationMinutes(startAt: Date | string, endAt: Date | string): number {


### PR DESCRIPTION
## Summary
- return `null` from `parseLocalDateTime` when parsing fails
- handle nullable parse results in `TaskModal`
- add malformed datetime cases to unit tests

## Testing
- `npm run lint`
- `CI=true npx vitest run src/lib/datetime.test.ts`
- `npm run build` *(fails: Creating an optimized production build ...)*


------
https://chatgpt.com/codex/tasks/task_e_68be60869a288320a16c73a005e10340