### PR TITLE
feat: add reset to error boundary

### DIFF
--- a/src/components/error-boundary.test.tsx
+++ b/src/components/error-boundary.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+import { act } from 'react-dom/test-utils';
+import { ErrorBoundary } from './error-boundary';
+
+expect.extend(matchers);
+
+function Bomb({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) {
+    throw new Error('boom');
+  }
+  return <div>Safe</div>;
+}
+
+describe('ErrorBoundary', () => {
+  it('captures errors and resets via button', () => {
+    const onReset = vi.fn();
+    const { rerender } = render(
+      <ErrorBoundary onReset={onReset}>
+        <Bomb shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Something went wrong');
+    const button = screen.getByRole('button', { name: /try again/i });
+
+    rerender(
+      <ErrorBoundary onReset={onReset}>
+        <Bomb shouldThrow={false} />
+      </ErrorBoundary>
+    );
+
+    fireEvent.click(button);
+    expect(onReset).toHaveBeenCalled();
+    expect(screen.getByText('Safe')).toBeInTheDocument();
+  });
+
+  it('allows reset via ref', () => {
+    const onReset = vi.fn();
+    const ref = React.createRef<ErrorBoundary>();
+    const { rerender } = render(
+      <ErrorBoundary ref={ref} onReset={onReset}>
+        <Bomb shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    rerender(
+      <ErrorBoundary ref={ref} onReset={onReset}>
+        <Bomb shouldThrow={false} />
+      </ErrorBoundary>
+    );
+
+    act(() => {
+      ref.current?.reset();
+    });
+    expect(onReset).toHaveBeenCalled();
+    expect(screen.getByText('Safe')).toBeInTheDocument();
+  });
+});

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -4,6 +4,7 @@ import React from "react";
 type ErrorBoundaryProps = {
   children: React.ReactNode;
   fallback?: React.ReactNode;
+  onReset?: () => void;
 };
 
 type ErrorBoundaryState = {
@@ -16,6 +17,11 @@ export class ErrorBoundary extends React.Component<
 > {
   state: ErrorBoundaryState = { hasError: false };
 
+  reset = () => {
+    this.setState({ hasError: false });
+    this.props.onReset?.();
+  };
+
   static getDerivedStateFromError(): ErrorBoundaryState {
     return { hasError: true };
   }
@@ -27,7 +33,10 @@ export class ErrorBoundary extends React.Component<
   render() {
     if (this.state.hasError) {
       return this.props.fallback ?? (
-        <div role="alert">Something went wrong</div>
+        <div role="alert">
+          <p>Something went wrong</p>
+          <button onClick={this.reset}>Try again</button>
+        </div>
       );
     }
     return this.props.children;


### PR DESCRIPTION
## Summary
- allow error boundary to reset and invoke callback
- cover error capture and reset behavior

## Testing
- `npm run lint`
- `npm test src/components/error-boundary.test.tsx`
- `npm run build` *(fails: Expected 1 arguments, but got 0)*

------
https://chatgpt.com/codex/tasks/task_e_68be608abd788320b1dd00a682b18536