### PR TITLE
feat: allow multiple toasts without dismissal

### DIFF
--- a/src/lib/toast.test.ts
+++ b/src/lib/toast.test.ts
@@ -44,4 +44,11 @@ describe("toast utility", () => {
     expect(mocks.dismiss).toHaveBeenCalled();
     expect(mocks.base).toHaveBeenCalledWith("FYI.", { duration: 3500 });
   });
+
+  it("allows multiple toasts when dismissal skipped", () => {
+    toast.success("One", false);
+    toast.success("Two", false);
+    expect(mocks.dismiss).not.toHaveBeenCalled();
+    expect(mocks.success).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -2,17 +2,23 @@ import { toast as hotToast } from "react-hot-toast";
 
 const base = { duration: 3500 } as const;
 
-function show(type: "success" | "error" | "info", message: string) {
-  hotToast.dismiss();
+function show(
+  type: "success" | "error" | "info",
+  message: string,
+  dismissAll = true,
+) {
+  if (dismissAll) hotToast.dismiss();
   if (type === "success") return hotToast.success(message, base);
   if (type === "error") return hotToast.error(message, base);
   return hotToast(message, base);
 }
 
 export const toast = {
-  success: (msg: string) => show("success", msg),
-  error: (msg: string) => show("error", msg),
-  info: (msg: string) => show("info", msg),
+  success: (msg: string, dismissAll = true) => show("success", msg, dismissAll),
+  error: (msg: string, dismissAll = true) => show("error", msg, dismissAll),
+  info: (msg: string, dismissAll = true) => show("info", msg, dismissAll),
 };
+
+export const dismissAll = () => hotToast.dismiss();
 
 export default toast;


### PR DESCRIPTION
## Summary
- allow toast helper to skip dismissing existing toasts
- export a dedicated `dismissAll` function
- test that multiple toasts can coexist

## Testing
- `npm run lint -- --dir src --file lib/toast.ts --file lib/toast.test.ts`
- `CI=true npm test src/lib/toast.test.ts`
- `npm run build` *(fails: Expected 1 arguments, but got 0 in taskBulk.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68be60d7ad3083208594571386eb14eb