### PR TITLE
fix: type-safe task status mutation

### DIFF
--- a/src/components/task-modal.test.tsx
+++ b/src/components/task-modal.test.tsx
@@ -83,6 +83,25 @@ describe('TaskModal due date editing', () => {
 
 });
 
+describe('TaskModal status changes', () => {
+  beforeEach(() => {
+    setStatusMutation.mutate.mockReset();
+    setStatusMutation.error = undefined;
+  });
+
+  it('calls setStatus when status is updated', () => {
+    const task = { id: 't1', title: 'Write essay', status: 'TODO', subject: null, notes: null, dueAt: null } as Task;
+    const onClose = vi.fn();
+    render(<TaskModal open mode="edit" onClose={onClose} task={task} />);
+
+    fireEvent.click(screen.getByLabelText('Change status'));
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }));
+
+    expect(setStatusMutation.mutate).toHaveBeenCalledWith({ id: 't1', status: 'DONE' });
+    expect(onClose).toHaveBeenCalled();
+  });
+});
+
 describe('TaskModal validation', () => {
   beforeEach(() => {
     mutateCreate.mockReset();

--- a/src/components/task-modal.tsx
+++ b/src/components/task-modal.tsx
@@ -37,7 +37,6 @@ export function TaskModal({
 }: TaskModalProps) {
   const utils = api.useUtils();
   const isEdit = mode === "edit";
-  const apiAny = api as any;
 
   const [title, setTitle] = useState("");
   const [titleError, setTitleError] = useState<string | null>(null);
@@ -122,11 +121,11 @@ export function TaskModal({
     },
   });
 
-  const setStatus = apiAny.task?.setStatus?.useMutation?.({
+  const setStatus = api.task.setStatus.useMutation({
     onSuccess: async () => {
       await utils.task.list.invalidate();
     },
-  }) ?? { mutate: () => {}, isPending: false, error: undefined };
+  });
 
   const del = api.task.delete.useMutation({
     onSuccess: async () => {

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -1,4 +1,4 @@
-import { inferRouterOutputs } from '@trpc/server';
+import { inferRouterOutputs, inferRouterInputs } from '@trpc/server';
 import { router } from './trpc';
 import { courseRouter } from './routers/course';
 import { eventRouter } from './routers/event';
@@ -18,3 +18,4 @@ export const appRouter = router({
 
 export type AppRouter = typeof appRouter;
 export type RouterOutputs = inferRouterOutputs<AppRouter>;
+export type RouterInputs = inferRouterInputs<AppRouter>;

--- a/src/server/api/routers/task/taskBulk.ts
+++ b/src/server/api/routers/task/taskBulk.ts
@@ -17,7 +17,7 @@ export const taskBulkRouter = router({
         where: { id: { in: input.ids }, userId },
         data: { status: input.status },
       });
-      await invalidateTaskListCache();
+      await invalidateTaskListCache(userId);
       return { success: true };
     }),
   bulkDelete: protectedProcedure
@@ -29,7 +29,7 @@ export const taskBulkRouter = router({
         db.event.deleteMany({ where: { taskId: { in: input.ids }, task: { userId } } }),
         db.task.deleteMany({ where: { id: { in: input.ids }, userId } }),
       ]);
-      await invalidateTaskListCache();
+      await invalidateTaskListCache(userId);
       return { success: true };
     }),
 });

--- a/src/server/api/routers/task/taskSchedule.ts
+++ b/src/server/api/routers/task/taskSchedule.ts
@@ -19,7 +19,7 @@ export const taskScheduleRouter = router({
           db.task.update({ where: { id }, data: { position: index + 1 } }),
         ),
       );
-      await invalidateTaskListCache();
+      await invalidateTaskListCache(userId);
       return { success: true };
     }),
 });


### PR DESCRIPTION
## Summary
- expose `RouterInputs` for tRPC router typings
- use typed `api.task.setStatus` in task modal
- cover status change regression in task modal test
- fix cache invalidation in task bulk and schedule routers

## Testing
- `npm run lint`
- `npm test src/components/task-modal.test.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be60af0d70832081fc82ca648777db