### PR TITLE
refactor: hoist filter options constant

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -104,10 +104,17 @@ describe('HomePage', () => {
         <HomePage />
       </>
     );
-    // Tabs are buttons styled as tabs; verify cycling changes selected label
-    expect(screen.getByRole('button', { name: /all/i })).toBeInTheDocument();
+    const allTab = screen.getByRole('button', { name: 'All' });
+    const todayTab = screen.getByRole('button', { name: 'Today' });
+    const overdueTab = screen.getByRole('button', { name: 'Overdue' });
+
+    expect(allTab).toHaveClass('bg-neutral-100');
     fireEvent.keyDown(window, { key: 'ArrowRight', ctrlKey: true });
-    expect(screen.getByRole('button', { name: /overdue/i })).toBeInTheDocument();
+    expect(todayTab).toHaveClass('bg-neutral-100');
+    fireEvent.keyDown(window, { key: 'ArrowRight', ctrlKey: true });
+    expect(overdueTab).toHaveClass('bg-neutral-100');
+    fireEvent.keyDown(window, { key: 'ArrowLeft', ctrlKey: true });
+    expect(todayTab).toHaveClass('bg-neutral-100');
   });
 
   it('shows shortcuts popover when clicking question mark', () => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,13 @@ import type { TaskStatus } from "@/components/status-dropdown";
 
 type Priority = "LOW" | "MEDIUM" | "HIGH";
 
+const FILTER_OPTIONS: Array<"all" | "overdue" | "today" | "archive"> = [
+  "all",
+  "today",
+  "overdue",
+  "archive",
+];
+
 export default function HomePage() {
   return (
     <Suspense fallback={null}>
@@ -68,13 +75,12 @@ function HomePageContent() {
       }
       if ((e.key === "ArrowRight" || e.key === "ArrowLeft") && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
-        const options: Array<"all" | "overdue" | "today" | "archive"> = ["all", "today", "overdue", "archive"];
-        const idx = options.indexOf(filter);
+        const idx = FILTER_OPTIONS.indexOf(filter);
         const nextIndex =
           e.key === "ArrowRight"
-            ? (idx + 1) % options.length
-            : (idx - 1 + options.length) % options.length;
-        setFilter(options[nextIndex]);
+            ? (idx + 1) % FILTER_OPTIONS.length
+            : (idx - 1 + FILTER_OPTIONS.length) % FILTER_OPTIONS.length;
+        setFilter(FILTER_OPTIONS[nextIndex]);
       }
     };
     window.addEventListener("keydown", onKeyDown);


### PR DESCRIPTION
## Summary
- define shared FILTER_OPTIONS outside of useEffect
- simplify keydown logic to reuse the hoisted constant
- strengthen filter cycling unit test

## Testing
- `npm run lint`
- `CI=true npx vitest run src/app/page.test.tsx`
- `npm run build` *(fails: Expected 1 arguments, but got 0 in taskBulk.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68be60d22e2883208c6fc5bf1b21b2c6