### PR TITLE
feat: centralize env schema

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,19 +1,20 @@
-import NextAuth from "next-auth";
-import type { NextAuthOptions } from "next-auth";
-import GoogleProvider from "next-auth/providers/google";
-import { PrismaAdapter } from "@next-auth/prisma-adapter";
-import { db } from "@/server/db";
+import NextAuth from 'next-auth';
+import type { NextAuthOptions } from 'next-auth';
+import GoogleProvider from 'next-auth/providers/google';
+import { PrismaAdapter } from '@next-auth/prisma-adapter';
+import { db } from '@/server/db';
+import { env } from '@/env';
 
 export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(db),
-  secret: process.env.NEXTAUTH_SECRET,
+  secret: env.NEXTAUTH_SECRET,
   // Use JWT sessions so next-auth middleware can authenticate requests.
   // Database sessions are not readable in the edge middleware and cause login loops.
   session: { strategy: "jwt" },
   providers: [
     GoogleProvider({
-      clientId: process.env.GOOGLE_CLIENT_ID!,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+      clientId: env.GOOGLE_CLIENT_ID,
+      clientSecret: env.GOOGLE_CLIENT_SECRET,
       // Allow linking Google to an existing user with the same email
       // This fixes OAuthAccountNotLinked when a user row already exists
       // (e.g., created before the Account row due to earlier schema errors).

--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect, vi } from 'vitest';
+
+describe('env validation', () => {
+  it('throws when required env vars are missing', async () => {
+    const original = process.env.DATABASE_URL;
+    delete process.env.DATABASE_URL;
+    vi.resetModules();
+    await expect(import('./env')).rejects.toThrow();
+    process.env.DATABASE_URL = original;
+    vi.resetModules();
+  });
+});

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+export const envSchema = z.object({
+  DATABASE_URL: z.string().url(),
+  NEXTAUTH_SECRET: z.string(),
+  GOOGLE_CLIENT_ID: z.string(),
+  GOOGLE_CLIENT_SECRET: z.string(),
+  REDIS_URL: z.string().url().optional(),
+  REDIS_TOKEN: z.string().optional(),
+  UPSTASH_REDIS_REST_URL: z.string().url().optional(),
+  UPSTASH_REDIS_REST_TOKEN: z.string().optional(),
+  NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
+});
+
+export const env = envSchema.parse(process.env);

--- a/src/server/cache.ts
+++ b/src/server/cache.ts
@@ -1,4 +1,5 @@
 import { Redis } from '@upstash/redis';
+import { env } from '@/env';
 
 export const CACHE_PREFIX = 'task:';
 
@@ -9,8 +10,8 @@ interface CacheStore {
   clear(): Promise<void>;
 }
 
-const url = process.env.UPSTASH_REDIS_REST_URL || process.env.REDIS_URL;
-const token = process.env.UPSTASH_REDIS_REST_TOKEN || process.env.REDIS_TOKEN;
+const url = env.UPSTASH_REDIS_REST_URL ?? env.REDIS_URL;
+const token = env.UPSTASH_REDIS_REST_TOKEN ?? env.REDIS_TOKEN;
 
 let store: CacheStore;
 

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+import { env } from '@/env';
 
 const globalForPrisma = globalThis as unknown as {
   prisma?: PrismaClient;
@@ -7,4 +8,4 @@ const globalForPrisma = globalThis as unknown as {
 export const db: PrismaClient =
   globalForPrisma.prisma ?? new PrismaClient();
 
-if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = db;
+if (env.NODE_ENV !== 'production') globalForPrisma.prisma = db;

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -2,6 +2,10 @@ import { vi, afterEach, beforeAll } from 'vitest';
 import { cleanup } from '@testing-library/react';
 // Force a deterministic timezone for date logic tests
 process.env.TZ = 'UTC';
+process.env.DATABASE_URL ??= 'postgres://localhost:5432/test';
+process.env.NEXTAUTH_SECRET ??= 'test-secret';
+process.env.GOOGLE_CLIENT_ID ??= 'test-google-id';
+process.env.GOOGLE_CLIENT_SECRET ??= 'test-google-secret';
 // Freeze time to a deterministic date so calendar/event tests render predictable weeks
 beforeAll(() => {
   vi.useFakeTimers();


### PR DESCRIPTION
## Summary
- add Zod-based env schema
- use env imports instead of process.env
- test invalid configs at startup

## Testing
- `npm run lint`
- `CI=true npm test` (fails: [vitest] No "useSearchParams" export is defined on the "next/navigation" mock)
- `DATABASE_URL=postgres://localhost:5432/test NEXTAUTH_SECRET=test GOOGLE_CLIENT_ID=test GOOGLE_CLIENT_SECRET=test npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf9e7759388320b0d96612a34ef2a0