### PR TITLE
feat: stabilize task list cache key serialization

### DIFF
--- a/src/server/api/routers/task/utils.test.ts
+++ b/src/server/api/routers/task/utils.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/server/db', () => ({ db: {} }));
+vi.mock('@/server/cache', () => ({ cache: { deleteByPrefix: vi.fn() } }));
+
+import { buildListCacheKey } from './utils';
+
+describe('buildListCacheKey', () => {
+  it('produces identical keys regardless of property order', () => {
+    const user = 'u1';
+    const first = { b: 2, a: 1, nested: { z: 1, y: 2 } };
+    const second = { nested: { y: 2, z: 1 }, a: 1, b: 2 };
+    const key1 = buildListCacheKey(first, user);
+    const key2 = buildListCacheKey(second, user);
+    expect(key1).toBe(key2);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `serializeSorted` helper to stringify objects with sorted keys
- use stable serialization when building task list cache keys
- test that cache keys are consistent despite property order

## Testing
- `npm run lint`
- `CI=true npm test src/server/api/routers/task/utils.test.ts`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf9e81ee608320a659c2d1903bce9b