### PR TITLE
fix: rely on next-themes for persistence

### DIFF
--- a/src/components/theme-toggle.test.tsx
+++ b/src/components/theme-toggle.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ThemeProvider } from 'next-themes';
+import { describe, it, expect, vi } from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+
+import ThemeToggle from './theme-toggle';
+
+expect.extend(matchers);
+
+describe('ThemeToggle', () => {
+  it('switches themes and persists via next-themes', async () => {
+    vi.useRealTimers();
+    localStorage.clear();
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+    render(
+      <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
+        <ThemeToggle />
+      </ThemeProvider>
+    );
+    const button = await screen.findByRole('button', { name: 'Toggle theme' });
+    fireEvent.click(button);
+    await waitFor(() => {
+      expect(localStorage.getItem('theme')).toBe('dark');
+      expect(document.documentElement).toHaveClass('dark');
+    });
+    vi.useFakeTimers();
+  });
+});
+

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -13,9 +13,6 @@ export default function ThemeToggle() {
   const toggle = () => {
     const nextTheme = theme === "dark" ? "light" : "dark";
     setTheme(nextTheme);
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem("theme", nextTheme);
-    }
   };
   return (
     <button


### PR DESCRIPTION
## Summary
- remove manual localStorage update in `ThemeToggle`
- add test verifying `next-themes` persists theme on toggle

## Testing
- `npm run lint`
- `CI=true npm test` *(fails: StatsPage visual regression snapshots mismatched)*
- `CI=true npx vitest run src/components/theme-toggle.test.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf9e917670832098a9ac1ee7b47dbc