### PR TITLE
feat: add start/stop controls for recurrence scheduler

### DIFF
--- a/src/server/jobs/recurrence.test.ts
+++ b/src/server/jobs/recurrence.test.ts
@@ -26,7 +26,10 @@ vi.mock('@/server/db', () => ({
   },
 }));
 
-import { generateRecurringTasks } from './recurrence';
+import {
+  generateRecurringTasks,
+  scheduleRecurringTasks,
+} from './recurrence';
 
 const baseTemplate = {
   title: 't',
@@ -191,5 +194,21 @@ describe('generateRecurringTasks', () => {
     expect(hoisted.create).toHaveBeenCalledTimes(1);
     const call = hoisted.create.mock.calls[0][0];
     expect(call.data.userId).toBe('u2');
+  });
+});
+
+describe('scheduleRecurringTasks', () => {
+  it('runs immediately and can be stopped', () => {
+    hoisted.findMany.mockReset();
+    hoisted.findMany.mockResolvedValue([]);
+    vi.useFakeTimers();
+    const job = scheduleRecurringTasks();
+    job.start();
+    expect(hoisted.findMany).toHaveBeenCalledTimes(1);
+    job.stop();
+    expect(vi.getTimerCount()).toBe(0);
+    vi.advanceTimersByTime(24 * 60 * 60 * 1000);
+    expect(hoisted.findMany).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
   });
 });

--- a/src/server/jobs/recurrence.ts
+++ b/src/server/jobs/recurrence.ts
@@ -70,10 +70,24 @@ export function scheduleRecurringTasks() {
     generateRecurringTasks().catch((err) =>
       console.error('recurrence job failed', err)
     );
-  run();
-  setInterval(run, DAY_MS);
+  let interval: NodeJS.Timeout | null = null;
+  return {
+    start() {
+      run();
+      interval = setInterval(run, DAY_MS);
+      return interval;
+    },
+    stop() {
+      if (interval) {
+        clearInterval(interval);
+        interval = null;
+      }
+    },
+  };
 }
 
 if (require.main === module) {
-  scheduleRecurringTasks();
+  const job = scheduleRecurringTasks();
+  job.start();
+  process.on('SIGTERM', job.stop);
 }


### PR DESCRIPTION
## Summary
- expose start/stop methods for recurring task scheduler and handle SIGTERM
- test scheduler runs immediately and cleans up timers on stop

## Testing
- `npm run lint -- --file src/server/jobs/recurrence.ts --file src/server/jobs/recurrence.test.ts`
- `CI=true npm test src/server/jobs/recurrence.test.ts`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf9e9e941c832081445123c9adf0c4