### PR TITLE
docs: tidy caching section

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,7 @@ npm run e2e
 
 ## Caching
 
-`taskRouter.list` caches query results for 60 seconds using an in-memory store backed by
-[`@upstash/redis`](https://github.com/upstash/redis).
-Any mutation that changes tasks (create, update, delete, reorder, etc.) clears the cache so
-subsequent `list` calls return fresh data. Configure Redis via `REDIS_URL` and `REDIS_TOKEN` or
-leave them unset to fall back to a local in-memory cache.
+`taskRouter.list` caches query results for 60 seconds using an in-memory store backed by [`@upstash/redis`](https://github.com/upstash/redis). Any mutation that changes tasks (create, update, delete, reorder, etc.) clears the cache so subsequent `list` calls return fresh data. Configure Redis via `REDIS_URL` and `REDIS_TOKEN` or leave them unset to fall back to a local in-memory cache.
 
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary
- streamline README caching explanation for clarity

## Testing
- `npm run lint`
- `CI=true npm test` *(fails: Cannot read properties of undefined)*
- `npm run build` *(fails: missing env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e4dd81308320bf1438ee5aa6511d