### PR TITLE
feat: restrict project modifications

### DIFF
--- a/src/server/api/routers/project.test.ts
+++ b/src/server/api/routers/project.test.ts
@@ -4,19 +4,19 @@ const hoisted = vi.hoisted(() => {
   const create = vi.fn().mockResolvedValue({});
   const update = vi.fn().mockResolvedValue({});
   const findFirst = vi.fn().mockResolvedValue({});
-  return { create, update, findFirst };
+  const del = vi.fn().mockResolvedValue({});
+  return { create, update, findFirst, delete: del };
 });
 
 vi.mock('@/server/db', () => ({
   db: {
     project: {
       findMany: vi.fn().mockResolvedValue([]),
-      findFirst: hoisted.findFirst,
       create: hoisted.create,
       update: hoisted.update,
       findFirst: hoisted.findFirst,
-      delete: vi.fn().mockResolvedValue({}),
-    },
+      delete: hoisted.delete,
+      },
   },
 }));
 
@@ -29,9 +29,9 @@ describe('projectRouter.create', () => {
   it('creates project with title, description and instructionsUrl', async () => {
     await projectRouter
       .createCaller({ session: { user: { id: 'u1' } } as any })
-      .create({ title: 'p', description: 'd', instructionsUrl: 'u.pdf' });
+      .create({ title: 'p', description: 'd', instructionsUrl: 'http://example.com/u.pdf' });
     expect(hoisted.create).toHaveBeenCalledWith({
-      data: { title: 'p', userId: 'u1', description: 'd', instructionsUrl: 'u.pdf' },
+      data: { title: 'p', userId: 'u1', description: 'd', instructionsUrl: 'http://example.com/u.pdf' },
     });
   });
 });
@@ -39,15 +39,26 @@ describe('projectRouter.create', () => {
 describe('projectRouter.update', () => {
   beforeEach(() => {
     hoisted.update.mockClear();
+    hoisted.findFirst.mockReset();
   });
   it('updates project fields', async () => {
+    hoisted.findFirst.mockResolvedValueOnce({ id: '1', userId: 'u1' });
     await projectRouter
-      .createCaller({})
-      .update({ id: '1', title: 'np', description: null, instructionsUrl: '/f.pdf' });
+      .createCaller({ session: { user: { id: 'u1' } } as any })
+      .update({ id: '1', title: 'np', description: null, instructionsUrl: 'http://example.com/f.pdf' });
+    expect(hoisted.findFirst).toHaveBeenCalledWith({ where: { id: '1' } });
     expect(hoisted.update).toHaveBeenCalledWith({
       where: { id: '1' },
-      data: { title: 'np', description: null, instructionsUrl: '/f.pdf' },
+      data: { title: 'np', description: null, instructionsUrl: 'http://example.com/f.pdf' },
     });
+  });
+  it('throws if user does not own project', async () => {
+    hoisted.findFirst.mockResolvedValueOnce({ id: '1', userId: 'u2' });
+    await expect(
+      projectRouter
+        .createCaller({ session: { user: { id: 'u1' } } as any })
+        .update({ id: '1', title: 'np' })
+    ).rejects.toHaveProperty('code', 'UNAUTHORIZED');
   });
 });
 
@@ -68,5 +79,28 @@ describe('projectRouter.byId', () => {
   it('fetches project for user', async () => {
     await projectRouter.createCaller({ session: { user: { id: 'u1' } } as any }).byId({ id: 'p1' });
     expect(hoisted.findFirst).toHaveBeenCalledWith({ where: { id: 'p1', userId: 'u1' } });
+  });
+});
+
+describe('projectRouter.delete', () => {
+  beforeEach(() => {
+    hoisted.delete.mockClear();
+    hoisted.findFirst.mockReset();
+  });
+  it('deletes project for user', async () => {
+    hoisted.findFirst.mockResolvedValueOnce({ id: 'p1', userId: 'u1' });
+    await projectRouter
+      .createCaller({ session: { user: { id: 'u1' } } as any })
+      .delete({ id: 'p1' });
+    expect(hoisted.findFirst).toHaveBeenCalledWith({ where: { id: 'p1' } });
+    expect(hoisted.delete).toHaveBeenCalledWith({ where: { id: 'p1' } });
+  });
+  it('throws if user does not own project', async () => {
+    hoisted.findFirst.mockResolvedValueOnce({ id: 'p1', userId: 'u2' });
+    await expect(
+      projectRouter
+        .createCaller({ session: { user: { id: 'u1' } } as any })
+        .delete({ id: 'p1' })
+    ).rejects.toHaveProperty('code', 'UNAUTHORIZED');
   });
 });


### PR DESCRIPTION
## Summary
- require authentication and ownership for project update/delete procedures
- add tests ensuring users can only modify their own projects

## Testing
- `npm run lint`
- `npm test src/server/api/routers/project.test.ts`
- `DATABASE_URL=file:./dev.db NEXTAUTH_SECRET=secret GOOGLE_CLIENT_ID=client GOOGLE_CLIENT_SECRET=secret npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0f47f157c832098a520ebf00576af