### PR TITLE
feat: add nextauth and github env vars

### DIFF
--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -1,12 +1,17 @@
 import { describe, it, expect, vi } from 'vitest';
 
 describe('env validation', () => {
-  it('throws when required env vars are missing', async () => {
-    const original = process.env.DATABASE_URL;
-    delete process.env.DATABASE_URL;
-    vi.resetModules();
-    await expect(import('./env')).rejects.toThrow();
-    process.env.DATABASE_URL = original;
-    vi.resetModules();
-  });
+  it.each(['DATABASE_URL', 'NEXTAUTH_URL', 'GITHUB_ID', 'GITHUB_SECRET'])
+    ('throws when %s is missing', async (key) => {
+      const original = process.env[key];
+      delete process.env[key];
+      vi.resetModules();
+      await expect(import('./env')).rejects.toThrow();
+      if (original === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = original;
+      }
+      vi.resetModules();
+    });
 });

--- a/src/env.ts
+++ b/src/env.ts
@@ -3,6 +3,9 @@ import { z } from 'zod';
 export const envSchema = z.object({
   DATABASE_URL: z.string().url(),
   NEXTAUTH_SECRET: z.string(),
+  NEXTAUTH_URL: z.string().url(),
+  GITHUB_ID: z.string(),
+  GITHUB_SECRET: z.string(),
   GOOGLE_CLIENT_ID: z.string(),
   GOOGLE_CLIENT_SECRET: z.string(),
   REDIS_URL: z.string().url().optional(),

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -4,6 +4,9 @@ import { cleanup } from '@testing-library/react';
 process.env.TZ = 'UTC';
 process.env.DATABASE_URL ??= 'postgres://localhost:5432/test';
 process.env.NEXTAUTH_SECRET ??= 'test-secret';
+process.env.NEXTAUTH_URL ??= 'http://localhost:3000';
+process.env.GITHUB_ID ??= 'test-github-id';
+process.env.GITHUB_SECRET ??= 'test-github-secret';
 process.env.GOOGLE_CLIENT_ID ??= 'test-google-id';
 process.env.GOOGLE_CLIENT_SECRET ??= 'test-google-secret';
 // Freeze time to a deterministic date so calendar/event tests render predictable weeks


### PR DESCRIPTION
## Summary
- expand env schema to include NEXTAUTH_URL, GITHUB_ID and GITHUB_SECRET
- seed test setup with defaults for new auth variables
- ensure env validation tests require new vars

## Testing
- `npm run lint`
- `CI=true npm test` *(fails: ERR_WORKER_OUT_OF_MEMORY)*
- `CI=true npm test src/env.test.ts`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0f48e6a60832093ea6e8e0e3841e5