### PR TITLE
chore: enforce strong NEXTAUTH_SECRET

### DIFF
--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -9,4 +9,22 @@ describe('env validation', () => {
     process.env.DATABASE_URL = original;
     vi.resetModules();
   });
+
+  it('throws when NEXTAUTH_SECRET is too short', async () => {
+    const original = process.env.NEXTAUTH_SECRET;
+    process.env.NEXTAUTH_SECRET = 'aA1!'.repeat(7) + 'aA1';
+    vi.resetModules();
+    await expect(import('./env')).rejects.toThrow();
+    process.env.NEXTAUTH_SECRET = original;
+    vi.resetModules();
+  });
+
+  it('throws when NEXTAUTH_SECRET lacks complexity', async () => {
+    const original = process.env.NEXTAUTH_SECRET;
+    process.env.NEXTAUTH_SECRET = 'a'.repeat(32);
+    vi.resetModules();
+    await expect(import('./env')).rejects.toThrow();
+    process.env.NEXTAUTH_SECRET = original;
+    vi.resetModules();
+  });
 });

--- a/src/env.ts
+++ b/src/env.ts
@@ -2,7 +2,13 @@ import { z } from 'zod';
 
 export const envSchema = z.object({
   DATABASE_URL: z.string().url(),
-  NEXTAUTH_SECRET: z.string(),
+  NEXTAUTH_SECRET: z
+    .string()
+    .min(32, 'NEXTAUTH_SECRET must be at least 32 characters')
+    .regex(
+      /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^a-zA-Z0-9]).+$/,
+      'NEXTAUTH_SECRET must include uppercase, lowercase, number, and special character',
+    ),
   GOOGLE_CLIENT_ID: z.string(),
   GOOGLE_CLIENT_SECRET: z.string(),
   REDIS_URL: z.string().url().optional(),


### PR DESCRIPTION
## Summary
- enforce minimum length and complexity for NEXTAUTH_SECRET
- add tests for weak NEXTAUTH_SECRET values

## Testing
- `npm run lint`
- `CI=true npm test src/env.test.ts`
- `CI=true DATABASE_URL=file:./dev.db NEXTAUTH_SECRET='Aa1!Aa1!Aa1!Aa1!Aa1!Aa1!Aa1!Aa1!' GOOGLE_CLIENT_ID=dummy GOOGLE_CLIENT_SECRET=dummy npm run build` *(fails: run terminated early)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f4944d9083209d9aec74bf078dfe