### PR TITLE
fix: clear in-memory cache directly

### DIFF
--- a/src/server/api/routers/task.test.ts
+++ b/src/server/api/routers/task.test.ts
@@ -51,7 +51,7 @@ vi.mock('@/server/db', () => ({
 }));
 
 import * as taskModule from './task';
-import { cache } from '@/server/cache';
+import { cache, CACHE_PREFIX } from '@/server/cache';
 
 const { taskRouter } = taskModule;
 const ctx = { session: { user: { id: 'user1' } } } as any;
@@ -59,7 +59,7 @@ const ctx = { session: { user: { id: 'user1' } } } as any;
 describe('taskRouter.list ordering', () => {
   beforeEach(async () => {
     hoisted.findMany.mockClear();
-    await cache.clear();
+    await cache.deleteByPrefix(CACHE_PREFIX);
   });
 
   it('orders by position, then priority, dueAt, then createdAt', async () => {
@@ -153,7 +153,7 @@ describe('taskRouter.list ordering', () => {
 describe('taskRouter.list caching', () => {
   beforeEach(async () => {
     hoisted.findMany.mockClear();
-    await cache.clear();
+    await cache.deleteByPrefix(CACHE_PREFIX);
   });
 
   it('caches per user and invalidates only for that user on create', async () => {

--- a/src/server/cache.test.ts
+++ b/src/server/cache.test.ts
@@ -48,18 +48,18 @@ afterEach(async () => {
 });
 
 describe('cache.clear', () => {
-  it('removes only keys with the app prefix', async () => {
-    const { cache, CACHE_PREFIX } = await getCacheModule();
-    const prefixedKey = `${CACHE_PREFIX}foo`;
-    const otherKey = 'other:bar';
+  it('removes all keys', async () => {
+    const { cache } = await getCacheModule();
+    const key1 = 'foo:1';
+    const key2 = 'bar:2';
 
-    await cache.set(prefixedKey, 1);
-    await cache.set(otherKey, 2);
+    await cache.set(key1, 1);
+    await cache.set(key2, 2);
 
     await cache.clear();
 
-    expect(await cache.get(prefixedKey)).toBeNull();
-    expect(await cache.get(otherKey)).toBe(2);
+    expect(await cache.get(key1)).toBeNull();
+    expect(await cache.get(key2)).toBeNull();
   });
 });
 

--- a/src/server/cache.ts
+++ b/src/server/cache.ts
@@ -35,7 +35,7 @@ const mapStore: CacheStore = {
     }
   },
   async clear() {
-    await this.deleteByPrefix(CACHE_PREFIX);
+    map.clear();
   },
 };
 


### PR DESCRIPTION
## Summary
- simplify mapStore.clear to reset entire in-memory cache
- adjust cache tests and task router tests for prefix-specific invalidation

## Testing
- `npm run lint`
- `CI=true npx vitest run src/server/cache.test.ts src/server/api/routers/task.test.ts`
- `npm run build` *(fails: DATABASE_URL, NEXTAUTH_SECRET, GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET are required)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f498cf448320ad5f80c1832af3db