### PR TITLE
feat: add LRU capacity limit to cache

### DIFF
--- a/src/server/cache.test.ts
+++ b/src/server/cache.test.ts
@@ -101,6 +101,25 @@ describe('cache.deleteByPrefix', () => {
   });
 });
 
+describe('cache.lru', () => {
+  it('evicts least recently used entries when limit is exceeded', async () => {
+    const { cache, MAX_CACHE_ENTRIES } = await getCacheModule();
+
+    for (let i = 0; i < MAX_CACHE_ENTRIES; i++) {
+      await cache.set(`key${i}`, i);
+    }
+
+    // Access key0 to make key1 the least recently used
+    expect(await cache.get('key0')).toBe(0);
+
+    await cache.set('new', MAX_CACHE_ENTRIES);
+
+    expect(await cache.get('key1')).toBeNull();
+    expect(await cache.get('key0')).toBe(0);
+    expect(await cache.get('new')).toBe(MAX_CACHE_ENTRIES);
+  });
+});
+
 describe('cache.ttl', () => {
   it('expires keys after ttl using Map implementation', async () => {
     vi.useFakeTimers();


### PR DESCRIPTION
## Summary
- cap in-memory cache at 1,000 entries and evict least recently used items
- test cache eviction logic

## Testing
- `npm run lint`
- `CI=true npm test src/server/cache.test.ts`
- `DATABASE_URL=file:./dev.db NEXTAUTH_SECRET=secret GOOGLE_CLIENT_ID=foo GOOGLE_CLIENT_SECRET=bar npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0f49a84e88320912c35a73cc80ba8