### PR TITLE
refactor: use logger for cache errors

### DIFF
--- a/src/server/cache.redis.test.ts
+++ b/src/server/cache.redis.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { logger } from '@/server/logger';
 
 // These tests simulate Redis errors to ensure the cache falls back to the
 // in-memory Map implementation.
@@ -26,7 +27,7 @@ describe('cache with failing Redis', () => {
   });
 
   it('falls back to map for get/set operations', async () => {
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
     const { cache } = await import('@/server/cache');
 
     await cache.set('foo', 'bar');
@@ -36,7 +37,7 @@ describe('cache with failing Redis', () => {
   });
 
   it('falls back to map for deleteByPrefix', async () => {
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
     const { cache } = await import('@/server/cache');
 
     await cache.set('foo:1', 1);

--- a/src/server/cache.ts
+++ b/src/server/cache.ts
@@ -1,5 +1,6 @@
 import { Redis } from '@upstash/redis';
 import { env } from '@/env';
+import { logger } from '@/server/logger';
 
 export const CACHE_PREFIX = 'task:';
 
@@ -49,7 +50,7 @@ if (url && token) {
       try {
         return (await redis.get<T>(key)) ?? null;
       } catch (err) {
-        console.error('Redis get error', err);
+        logger.error('Redis get error', err);
         return mapStore.get<T>(key);
       }
     },
@@ -57,7 +58,7 @@ if (url && token) {
       try {
         await redis.set(key, value, ttlSeconds ? { ex: ttlSeconds } : undefined);
       } catch (err) {
-        console.error('Redis set error', err);
+        logger.error('Redis set error', err);
         await mapStore.set(key, value, ttlSeconds);
       }
     },
@@ -75,7 +76,7 @@ if (url && token) {
           cursor = Number(nextCursor);
         } while (cursor !== 0);
       } catch (err) {
-        console.error('Redis deleteByPrefix error', err);
+        logger.error('Redis deleteByPrefix error', err);
         await mapStore.deleteByPrefix(prefix);
       }
     },
@@ -83,7 +84,7 @@ if (url && token) {
       try {
         await this.deleteByPrefix(CACHE_PREFIX);
       } catch (err) {
-        console.error('Redis clear error', err);
+        logger.error('Redis clear error', err);
         await mapStore.clear();
       }
     },

--- a/src/server/logger.ts
+++ b/src/server/logger.ts
@@ -1,0 +1,14 @@
+export const logger = {
+  error: (...args: unknown[]) => {
+    console.error(...args);
+  },
+  warn: (...args: unknown[]) => {
+    console.warn(...args);
+  },
+  info: (...args: unknown[]) => {
+    console.info(...args);
+  },
+  debug: (...args: unknown[]) => {
+    console.debug(...args);
+  },
+};


### PR DESCRIPTION
## Summary
- use project logger in cache module
- provide basic logger implementation and update tests

## Testing
- `npm run lint`
- `CI=true npm test` *(fails: Worker terminated due to reaching memory limit: JS heap out of memory)*
- `npm run build` *(fails: Failed to collect page data for /api/auth/[...nextauth])*

------
https://chatgpt.com/codex/tasks/task_e_68c0f49cc574832092708a82e69799ce