### PR TITLE
fix: handle cross-midnight events

### DIFF
--- a/src/server/api/routers/event.ts
+++ b/src/server/api/routers/event.ts
@@ -50,11 +50,8 @@ export const eventRouter = router({
       const existing: EventModel[] = await db.event.findMany({
         where: {
           task: { userId },
-          // Consider same day events for overlap avoidance
-          OR: [
-            { startAt: { gte: sameDayStart, lte: sameDayEnd } },
-            { endAt: { gte: sameDayStart, lte: sameDayEnd } },
-          ],
+          // Consider events overlapping the day for overlap avoidance
+          AND: { startAt: { lt: sameDayEnd }, endAt: { gt: sameDayStart } },
         },
       });
 
@@ -139,10 +136,7 @@ export const eventRouter = router({
         where: {
           task: { userId },
           id: { not: input.eventId },
-          OR: [
-            { startAt: { gte: sameDayStart, lte: sameDayEnd } },
-            { endAt: { gte: sameDayStart, lte: sameDayEnd } },
-          ],
+          AND: { startAt: { lt: sameDayEnd }, endAt: { gt: sameDayStart } },
         },
       });
 


### PR DESCRIPTION
## Summary
- ensure scheduling and moving consider events spanning midnight
- add tests for cross-midnight event overlaps

## Testing
- `npm run lint`
- `CI=true npx vitest run src/server/api/routers/event.test.ts`
- `npm run build` *(fails: Required env vars DATABASE_URL,NEXTAUTH_SECRET,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f4a13250832084dc7ed1711c03bf