### PR TITLE
fix: escape special characters in iCal export

### DIFF
--- a/src/server/api/routers/event.test.ts
+++ b/src/server/api/routers/event.test.ts
@@ -190,6 +190,22 @@ describe('eventRouter.ical', () => {
     expect(ics).toContain('BEGIN:VCALENDAR');
     expect(ics).toContain('SUMMARY:Test Event');
   });
+
+  it('escapes commas, semicolons, and newlines', async () => {
+    hoisted.findMany.mockResolvedValueOnce([
+      {
+        id: 'e1',
+        startAt: new Date('2023-01-01T10:00:00.000Z'),
+        endAt: new Date('2023-01-01T11:00:00.000Z'),
+        location: 'Room 1, Building; A\nSecond Line',
+        task: { title: 'Title, part; more\nLine' },
+      },
+    ]);
+
+    const ics = await eventRouter.createCaller(ctx).ical();
+    expect(ics).toContain('SUMMARY:Title\\, part\\; more\\nLine');
+    expect(ics).toContain('LOCATION:Room 1\\, Building\\; A\\nSecond Line');
+  });
 });
 
 describe('eventRouter.syncGoogle', () => {

--- a/src/server/api/routers/event.ts
+++ b/src/server/api/routers/event.ts
@@ -184,6 +184,8 @@ export const eventRouter = router({
         const pad = (n: number) => `${n}`.padStart(2, '0');
         return `${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}T${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}${pad(d.getUTCSeconds())}Z`;
       };
+      const escapeText = (text: string) =>
+        text.replace(/,/g, '\\,').replace(/;/g, '\\;').replace(/\r?\n/g, '\\n');
       const lines = [
         'BEGIN:VCALENDAR',
         'VERSION:2.0',
@@ -195,8 +197,8 @@ export const eventRouter = router({
         lines.push(`DTSTAMP:${formatDate(new Date())}`);
         lines.push(`DTSTART:${formatDate(new Date(e.startAt))}`);
         lines.push(`DTEND:${formatDate(new Date(e.endAt))}`);
-        if (e.task?.title) lines.push(`SUMMARY:${e.task.title}`);
-        if (e.location) lines.push(`LOCATION:${e.location}`);
+        if (e.task?.title) lines.push(`SUMMARY:${escapeText(e.task.title)}`);
+        if (e.location) lines.push(`LOCATION:${escapeText(e.location)}`);
         lines.push('END:VEVENT');
       }
       lines.push('END:VCALENDAR');


### PR DESCRIPTION
## Summary
- escape commas, semicolons, and newlines before writing SUMMARY and LOCATION in iCal export
- test escaping logic for iCal SUMMARY and LOCATION fields

## Testing
- `npm run lint`
- `CI=true npm test src/server/api/routers/event.test.ts`
- `DATABASE_URL=postgres://localhost NEXTAUTH_SECRET=secret GOOGLE_CLIENT_ID=foo GOOGLE_CLIENT_SECRET=bar npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0f4afaa448320b9a0f1d31bb4c8d9