### PR TITLE
refactor: centralize timezone day bounds computation

### DIFF
--- a/src/server/api/routers/task/timezone.test.ts
+++ b/src/server/api/routers/task/timezone.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { computeTodayBounds } from './timezone';
+
+describe('computeTodayBounds', () => {
+  it('returns explicit bounds when provided', () => {
+    const start = new Date('2024-01-01T00:00:00.000Z');
+    const end = new Date('2024-01-01T23:59:59.999Z');
+    const { startUtc, endUtc } = computeTodayBounds({
+      nowUtc: new Date('2024-01-01T12:00:00Z'),
+      todayStart: start,
+      todayEnd: end,
+    });
+    expect(startUtc).toEqual(start);
+    expect(endUtc).toEqual(end);
+  });
+
+  it('computes bounds for tz offset', () => {
+    const now = new Date('2024-05-15T10:20:30Z');
+    const { startUtc, endUtc } = computeTodayBounds({ nowUtc: now, tzOffsetMinutes: 300 });
+    expect(startUtc.toISOString()).toBe('2024-05-15T05:00:00.000Z');
+    expect(endUtc.toISOString()).toBe('2024-05-16T04:59:59.999Z');
+  });
+});

--- a/src/server/api/routers/task/timezone.ts
+++ b/src/server/api/routers/task/timezone.ts
@@ -1,0 +1,35 @@
+export const computeTodayBounds = (opts: {
+  nowUtc: Date;
+  timezone?: string | null;
+  tzOffsetMinutes?: number | null;
+  todayStart?: Date;
+  todayEnd?: Date;
+}): { startUtc: Date; endUtc: Date } => {
+  const { nowUtc, timezone, tzOffsetMinutes, todayStart, todayEnd } = opts;
+  if (todayStart && todayEnd) return { startUtc: todayStart, endUtc: todayEnd };
+  if (timezone) {
+    const nowTz = new Date(nowUtc.toLocaleString('en-US', { timeZone: timezone }));
+    const startTz = new Date(nowTz);
+    startTz.setHours(0, 0, 0, 0);
+    const endTz = new Date(nowTz);
+    endTz.setHours(23, 59, 59, 999);
+    const startUtc = new Date(startTz.toLocaleString('en-US', { timeZone: 'UTC' }));
+    const endUtc = new Date(endTz.toLocaleString('en-US', { timeZone: 'UTC' }));
+    return { startUtc, endUtc };
+  }
+  const nowClient =
+    tzOffsetMinutes != null ? new Date(nowUtc.getTime() - tzOffsetMinutes * 60 * 1000) : nowUtc;
+  const startClient = new Date(nowClient);
+  startClient.setHours(0, 0, 0, 0);
+  const endClient = new Date(nowClient);
+  endClient.setHours(23, 59, 59, 999);
+  const startUtc =
+    tzOffsetMinutes != null
+      ? new Date(startClient.getTime() + tzOffsetMinutes * 60 * 1000)
+      : startClient;
+  const endUtc =
+    tzOffsetMinutes != null
+      ? new Date(endClient.getTime() + tzOffsetMinutes * 60 * 1000)
+      : endClient;
+  return { startUtc, endUtc };
+};


### PR DESCRIPTION
## Summary
- extract timezone-based day boundary calculation into `computeTodayBounds`
- simplify `taskCrud.list` to reuse the helper
- add unit tests for timezone boundary helper

## Testing
- `npm run lint`
- `CI=true npx vitest run src/server/api/routers/task/timezone.test.ts src/server/api/routers/task/utils.test.ts`
- `npm run build` *(fails: Required environment variables missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f4b5589483208fb844fee541002c