### PR TITLE
refactor: centralize recurrence validation

### DIFF
--- a/src/server/api/routers/task/utils.test.ts
+++ b/src/server/api/routers/task/utils.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it, vi } from 'vitest';
 vi.mock('@/server/db', () => ({ db: {} }));
 vi.mock('@/server/cache', () => ({ cache: { deleteByPrefix: vi.fn() } }));
 
-import { buildListCacheKey } from './utils';
+import { buildListCacheKey, validateRecurrence } from './utils';
+import { RecurrenceType } from '@prisma/client';
+import { TRPCError } from '@trpc/server';
 
 describe('buildListCacheKey', () => {
   it('produces identical keys regardless of property order', () => {
@@ -13,6 +15,40 @@ describe('buildListCacheKey', () => {
     const key1 = buildListCacheKey(first, user);
     const key2 = buildListCacheKey(second, user);
     expect(key1).toBe(key2);
+  });
+});
+
+describe('validateRecurrence', () => {
+  it('throws when both recurrenceCount and recurrenceUntil are provided', () => {
+    expect(() =>
+      validateRecurrence({
+        recurrenceType: RecurrenceType.DAILY,
+        recurrenceInterval: 1,
+        recurrenceCount: 2,
+        recurrenceUntil: new Date(),
+      }),
+    ).toThrow(TRPCError);
+  });
+
+  it('requires a non-NONE recurrenceType when other fields exist', () => {
+    expect(() =>
+      validateRecurrence({ recurrenceInterval: 2 }),
+    ).toThrow(TRPCError);
+    expect(() =>
+      validateRecurrence({
+        recurrenceType: RecurrenceType.NONE,
+        recurrenceUntil: new Date(),
+      }),
+    ).toThrow(TRPCError);
+  });
+
+  it('accepts valid recurrence details', () => {
+    expect(() =>
+      validateRecurrence({
+        recurrenceType: RecurrenceType.WEEKLY,
+        recurrenceInterval: 1,
+      }),
+    ).not.toThrow();
   });
 });
 


### PR DESCRIPTION
## Summary
- extract recurrence validation into reusable `validateRecurrence`
- use shared recurrence validator in task create/update mutations
- add unit tests for recurrence validator

## Testing
- `npm run lint`
- `CI=true npm test src/server/api/routers/task.test.ts src/server/api/routers/task/utils.test.ts`
- `npm run build` *(fails: Creating an optimized production build ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f4bab1c483209650f5dfa7276262