### PR TITLE
refactor: use date-fns parse for datetime

### DIFF
--- a/src/lib/datetime.test.ts
+++ b/src/lib/datetime.test.ts
@@ -45,4 +45,18 @@ describe('datetime utility', () => {
       expect(parseLocalDateTime(c)).toBeNull();
     }
   });
+
+  it('handles leap years and invalid dates', () => {
+    const leap = parseLocalDateTime('2024-02-29T12:00');
+    expect(leap).not.toBeNull();
+    expect(leap?.getFullYear()).toBe(2024);
+    expect(leap?.getMonth()).toBe(1);
+    expect(leap?.getDate()).toBe(29);
+
+    const nonLeap = parseLocalDateTime('2023-02-29T12:00');
+    expect(nonLeap).toBeNull();
+
+    const invalidDate = parseLocalDateTime('2024-02-30T12:00');
+    expect(invalidDate).toBeNull();
+  });
 });

--- a/src/lib/datetime.ts
+++ b/src/lib/datetime.ts
@@ -1,4 +1,4 @@
-import { format } from 'date-fns';
+import { format, parse, isValid } from 'date-fns';
 
 const DATETIME_LOCAL_FORMAT = "yyyy-MM-dd'T'HH:mm";
 
@@ -8,25 +8,10 @@ export function formatLocalDateTime(date: Date): string {
 
 export function parseLocalDateTime(value: string): Date | null {
   // Expecting 'yyyy-MM-ddTHH:mm' (no timezone); interpret as local time explicitly
-  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/);
-  if (!match) return null;
-  const [, yStr, mStr, dStr, hhStr, mmStr] = match;
-  const y = Number(yStr);
-  const m = Number(mStr) - 1; // JS months are 0-indexed
-  const d = Number(dStr);
-  const hh = Number(hhStr);
-  const mm = Number(mmStr);
-  const date = new Date(y, m, d, hh, mm, 0, 0);
-  if (
-    date.getFullYear() !== y ||
-    date.getMonth() !== m ||
-    date.getDate() !== d ||
-    date.getHours() !== hh ||
-    date.getMinutes() !== mm
-  ) {
-    return null;
-  }
-  return date;
+  const parsed = parse(value, DATETIME_LOCAL_FORMAT, new Date());
+  if (!isValid(parsed)) return null;
+  if (format(parsed, DATETIME_LOCAL_FORMAT) !== value) return null;
+  return parsed;
 }
 
 export function calculateDurationMinutes(startAt: Date | string, endAt: Date | string): number {


### PR DESCRIPTION
## Summary
- replace regex datetime parsing with `date-fns/parse`
- test leap year and invalid date cases for parseLocalDateTime

## Testing
- `CI=true npm test src/lib/datetime.test.ts`
- `npm run lint`
- `npm run build` *(fails: Required environment variables are not set)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f4cac3348320929da8a29769eea6