### PR TITLE
feat: allow configuring LLM connections in settings

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,6 +25,9 @@ model User {
   dayWindowEndHour     Int     @default(18)
   defaultDurationMinutes Int   @default(30)
   googleSyncEnabled    Boolean @default(true)
+  llmProvider          LlmProvider @default(NONE)
+  openaiApiKey         String?  @db.Text
+  lmStudioUrl          String   @default("http://localhost:1234")
 
   tasks    Task[]
   projects Project[]
@@ -181,4 +184,10 @@ model TaskTimeLog {
 
   @@index([taskId])
   @@index([userId])
+}
+
+enum LlmProvider {
+  NONE
+  OPENAI
+  LM_STUDIO
 }

--- a/src/app/settings/page.test.tsx
+++ b/src/app/settings/page.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, beforeEach } from "vitest";
 import * as matchers from "@testing-library/jest-dom/matchers";
 expect.extend(matchers);
@@ -34,5 +34,22 @@ describe("SettingsPage", () => {
     render(<SettingsPage />);
     const checkbox = screen.getByLabelText(/enable google calendar sync/i) as HTMLInputElement;
     expect(checkbox.checked).toBe(true);
+  });
+
+  it("defaults the AI provider to none", () => {
+    render(<SettingsPage />);
+    const provider = screen.getByLabelText(/ai provider/i) as HTMLSelectElement;
+    expect(provider.value).toBe("NONE");
+    const urlInput = screen.getByLabelText(/lm studio url/i) as HTMLInputElement;
+    expect(urlInput.value).toBe("http://localhost:1234");
+    expect(urlInput).toBeDisabled();
+  });
+
+  it("enables LM Studio configuration when selected", () => {
+    render(<SettingsPage />);
+    const provider = screen.getByLabelText(/ai provider/i) as HTMLSelectElement;
+    fireEvent.change(provider, { target: { value: "LM_STUDIO" } });
+    const urlInput = screen.getByLabelText(/lm studio url/i) as HTMLInputElement;
+    expect(urlInput).not.toBeDisabled();
   });
 });

--- a/src/server/api/routers/user.test.ts
+++ b/src/server/api/routers/user.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { LlmProvider } from '@prisma/client';
 import { userRouter } from './user';
 
 const hoisted = vi.hoisted(() => {
@@ -10,6 +11,10 @@ vi.mock('@/server/db', () => ({
   db: { user: { update: hoisted.update } },
 }));
 
+beforeEach(() => {
+  hoisted.update.mockClear();
+});
+
 describe('userRouter.setTimezone', () => {
   it('updates timezone for authenticated user', async () => {
     await userRouter.createCaller({ session: { user: { id: 'u1' } } as any }).setTimezone({ timezone: 'UTC' });
@@ -18,5 +23,52 @@ describe('userRouter.setTimezone', () => {
 
   it('throws when unauthenticated', async () => {
     await expect(userRouter.createCaller({}).setTimezone({ timezone: 'UTC' })).rejects.toThrow();
+  });
+});
+
+describe('userRouter.setSettings', () => {
+  const caller = userRouter.createCaller({ session: { user: { id: 'u1' } } as any });
+
+  it('updates scheduling and AI preferences', async () => {
+    await caller.setSettings({
+      timezone: 'UTC',
+      dayWindowStartHour: 9,
+      dayWindowEndHour: 18,
+      defaultDurationMinutes: 45,
+      googleSyncEnabled: false,
+      llmProvider: LlmProvider.LM_STUDIO,
+      openaiApiKey: null,
+      lmStudioUrl: 'http://localhost:1234',
+    });
+
+    expect(hoisted.update).toHaveBeenCalledWith({
+      where: { id: 'u1' },
+      data: {
+        timezone: 'UTC',
+        dayWindowStartHour: 9,
+        dayWindowEndHour: 18,
+        defaultDurationMinutes: 45,
+        googleSyncEnabled: false,
+        llmProvider: LlmProvider.LM_STUDIO,
+        openaiApiKey: null,
+        lmStudioUrl: 'http://localhost:1234',
+      },
+    });
+  });
+
+  it('requires an OpenAI key when selecting the OpenAI provider', async () => {
+    await expect(
+      caller.setSettings({
+        timezone: 'UTC',
+        dayWindowStartHour: 8,
+        dayWindowEndHour: 17,
+        defaultDurationMinutes: 30,
+        googleSyncEnabled: true,
+        llmProvider: LlmProvider.OPENAI,
+        openaiApiKey: null,
+        lmStudioUrl: 'http://localhost:1234',
+      })
+    ).rejects.toThrow(/openai api key/i);
+    expect(hoisted.update).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add per-user LLM provider, API key, and LM Studio URL fields to the Prisma schema
- expand the settings page to configure OpenAI or LM Studio connections with client-side validation
- extend user settings API logic and tests plus new UI tests for the LLM controls

## Testing
- npm run lint
- npm test *(fails: multiple unrelated suites require extensive mocks and snapshots in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e0c65cf8832091c607d091c8cf78