### PR TITLE
Respect user timezone in scheduler

### DIFF
--- a/src/server/ai/timezone.ts
+++ b/src/server/ai/timezone.ts
@@ -1,0 +1,64 @@
+import { Interval } from '@/lib/scheduling';
+
+export type TimezoneConverter = {
+  toZoned: (instant: Date) => Date;
+  toUtc: (instant: Date) => Date;
+  intervalToZoned: (interval: Interval) => Interval;
+  intervalToUtc: (interval: Interval) => Interval;
+};
+
+const IDENTITY_CONVERTER: TimezoneConverter = {
+  toZoned: (instant) => new Date(instant),
+  toUtc: (instant) => new Date(instant),
+  intervalToZoned: (interval) => ({
+    startAt: new Date(interval.startAt),
+    endAt: new Date(interval.endAt),
+  }),
+  intervalToUtc: (interval) => ({
+    startAt: new Date(interval.startAt),
+    endAt: new Date(interval.endAt),
+  }),
+};
+
+export function createTimezoneConverter(timezone: string | null | undefined): TimezoneConverter {
+  if (!timezone) return IDENTITY_CONVERTER;
+
+  return {
+    toZoned: (instant) => convertToTimezone(instant, timezone),
+    toUtc: (instant) => convertFromTimezoneToUtc(instant, timezone),
+    intervalToZoned: (interval) => ({
+      startAt: convertToTimezone(interval.startAt, timezone),
+      endAt: convertToTimezone(interval.endAt, timezone),
+    }),
+    intervalToUtc: (interval) => ({
+      startAt: convertFromTimezoneToUtc(interval.startAt, timezone),
+      endAt: convertFromTimezoneToUtc(interval.endAt, timezone),
+    }),
+  };
+}
+
+function convertToTimezone(instant: Date, timezone: string): Date {
+  const offsetMs = getOffsetMs(instant, timezone);
+  return new Date(instant.getTime() - offsetMs);
+}
+
+function convertFromTimezoneToUtc(instant: Date, timezone: string): Date {
+  let utc = new Date(instant);
+  for (let i = 0; i < 5; i++) {
+    const offset = getOffsetMs(utc, timezone);
+    const candidate = new Date(instant.getTime() + offset);
+    if (Math.abs(candidate.getTime() - utc.getTime()) < 1) return candidate;
+    utc = candidate;
+  }
+  return utc;
+}
+
+function getOffsetMs(instant: Date, timezone: string): number {
+  try {
+    const localized = instant.toLocaleString('en-US', { timeZone: timezone });
+    const localDate = new Date(localized);
+    return instant.getTime() - localDate.getTime();
+  } catch {
+    return 0;
+  }
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -125,6 +125,7 @@ vi.mock('@prisma/client', () => {
   return {
     TaskPriority: { LOW: 'LOW', MEDIUM: 'MEDIUM', HIGH: 'HIGH' },
     TaskStatus: { TODO: 'TODO', IN_PROGRESS: 'IN_PROGRESS', DONE: 'DONE', CANCELLED: 'CANCELLED' },
+    LlmProvider: { NONE: 'NONE', OPENAI: 'OPENAI', LM_STUDIO: 'LM_STUDIO' },
     RecurrenceType: { NONE: 'NONE', DAILY: 'DAILY', WEEKLY: 'WEEKLY', MONTHLY: 'MONTHLY' },
     Prisma: {},
   } as any;


### PR DESCRIPTION
## Summary
- adjust the scheduler to translate current time, candidate slots, and existing events into the user's timezone before evaluating working hours
- add reusable timezone conversion helpers to keep interval math consistent and convert scheduled slots back to UTC instants
- expand scheduler tests for non-UTC users and update the Prisma enum mock with LlmProvider support

## Testing
- npx vitest run src/server/ai/scheduler.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ddf6915978832091635f4f35b51610